### PR TITLE
Feature/132 pester5 tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,8 +38,10 @@ Note that we rely on `Windows PowerShell` (FullCLR), and not `PowerShell Core` (
 ## Install
 Open a PowerShell, then you can find and install the ISHRemote module. CurrentUser `-Scope` indicates that you don't have to run PowerShell as Administrator. The `-Force` will make you bypass some security/trust questions.
 
-		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12  # as PSGallery switched to HTTPS over Tls12 and higher
-        Install-Module ISHRemote -Repository PSGallery -Scope CurrentUser -Force 
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12  # as PSGallery switched to HTTPS over Tls12 and higher
+Install-Module ISHRemote -Repository PSGallery -Scope CurrentUser -Force 
+```
 
 ![ISHRemote-0.7--InstallModuleFromPSGallery 1024x512](./Doc/Images/ISHRemote-0.7--InstallModuleFromPSGallery.gif)
 
@@ -47,15 +49,18 @@ Open a PowerShell, then you can find and install the ISHRemote module. CurrentUs
 
 Open a PowerShell and run.
 
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12  # as PSGallery switched to HTTPS over Tls12 and higher
-        Update-Module ISHRemote
-
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12  # as PSGallery switched to HTTPS over Tls12 and higher
+Update-Module ISHRemote
+```
  
 ## Uninstall
 
 Open a PowerShell and run.
 
-        Uninstall-Module ISHRemote -AllVersion 
+```powershell
+Uninstall-Module ISHRemote -AllVersion 
+```
 
 # Backlog & Feedback
 Any feedback is welcome. Please log a GitHub issue, make sure you submit your version number, expected and current result,...
@@ -72,20 +77,6 @@ Any feedback is welcome. Please log a GitHub issue, make sure you submit your ve
   it probably means you didn't provide enough (mandatory) parameters to the WCF/SVC code so passing null parameters. Typically an `-IshPassword` is missing or using an existing username.
 * ISHDeploy `Enable-ISHIntegrationSTSInternalAuthentication/Disable-ISHIntegrationSTSInternalAuthentication` adds a /ISHWS/Internal/connectionconfiguration.xml that a different issuer should be used. As ISHRemote doesn't have an app.config, all the artifacts are derived from the RelyingParty WSDL provided mex endpoint (e.g. /ISHSTS/issue/wstrust/mex).  
 If you get error `New-IshSession : The communication object, System.ServiceModel.Channels.ServiceChannel, cannot be used for communication because it is in the Faulted state.`, it probably means you initialized `-WsBaseUrl` without the `/Internal/` (or `/SDL/`) segment, meaning you are using the primary configured STS.
-
-## Testing Known Issues
-
-* If a test fails with `Object reference not set to an instance of an object.`, it probably means that somewhere in your `*.Tests.ps1` you return an object and forgot a `Write-Host` or something.
-
-        Result StackTrace: 
-        at PowerShellTools.TestAdapter.PowerShellTestExecutor.RunTest(PowerShell powerShell, TestCase testCase, IRunContext runContext)
-        at PowerShellTools.TestAdapter.PowerShellTestExecutor.RunTests(IEnumerable``1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
-
-* When using Visual Studio to run a single "Run Selected Test", the Test Explorer in turn will 
-  run an [Invoke-Pester](https://github.com/pester/Pester/wiki/Invoke-Pester) command with the following parameters
-    * `Path` The path where Invoke-Pester begins to search for test files. The default is the current directory.
-    * `TestName` Informs Invoke-Pester to only run Describe blocks that match this name. This value may contain wildcards.  
-    This means that all `*.Tests.ps1` are executed in the same folder back-to-back, but only the Describe that matches the given TestName will be trully tested. So every `*.Tests.ps1` prerequisites and finally block will be called and have to be clean.
 
 ## Documentation Known Issues
 * [XmlDoc2CmdletDoc bug 22](https://github.com/red-gate/XmlDoc2CmdletDoc/issues/22) `System.ArgumentException: Property Get method was not found.` at `XmlDoc2CmdletDoc.Core.Domain.Parameter.get_DefaultValue()`   means you are missing a Get'er on a Property like `public IshFolder IshFolder { set { _folderId = value.IshFolderRef; } }`
@@ -121,17 +112,19 @@ synchronized with the code.
 ## Testing Standards
 
 Initial testing was based on Pester 3.4.0 which came as part of Windows 10/2016, to introduce support for PowerShell 7+ we switched to Pester 5+ ([#115](https://github.com/RWS/ISHRemote/issues/115)|[#132](https://github.com/RWS/ISHRemote/issues/132)). To force an upgrade from pre-packaged Pester 3.4.0, have a look at [Pester Installation](https://pester.dev/docs/introduction/installation), although on most systems it comes down to
-`Install-Module -Name Pester -Force -SkipPublisherCheck``.
+`Install-Module -Name Pester -Force -SkipPublisherCheck`.
 * Most Pester tests are acceptance test, enriched which some unit tests where possible.
 * Using a central `ISHRemote.PesterSetup.ps1` (with optional `ISHRemote.PesterSetup.Debug.ps1` override) in all `*.Tests.ps1` to specify the variables (not initialization) consistently
 * Data initialization and breakdown are key but also time consuming. After a test run, your system is left in its original state.
+
+In `ISHRemote.PesterSetup.Debug.ps1` override the global variables used for tests. **Don't forget not to commit those custom values**.
 
 # Coding Prerequisites and Best Practices
 
 ## Release Build and Publish To PowerShell Gallery
 
 Rought steps to release...
-1. Use Visual Studio to build a `Debug` build. Run an `Invoke-Pester` on `C:\GITHUB\ishremote\Source\ISHRemote\Trisoft.ISHRemote`. All steps should be green.
+1. Use Visual Studio to build a `Debug` build. Run an `Invoke-Pester` (minimally v5.3.0) on `C:\GITHUB\ishremote\Source\ISHRemote\Trisoft.ISHRemote`. All steps should be green.
 1. Use Visual Studio to build a `Release` build. Change `C:\GITHUB\ISHRemote\Source\ISHRemote\Trisoft.ISHRemote\ISHRemote.PesterSetup.ps1` to forcefully load `\bin\release\` (instead of `\bin\debug\`). Run an `Invoke-Pester` on `C:\GITHUB\ishremote\Source\ISHRemote\Trisoft.ISHRemote`. All steps should be green.
 1. The folder content of `C:\GITHUB\ISHRemote\Source\ISHRemote\Trisoft.ISHRemote\bin\Release\` will be published
     1. Check all files, especially `Scripts` that you have all files.
@@ -140,45 +133,8 @@ Rought steps to release...
 1. Check availability of latest version on https://www.powershellgallery.com/packages/ISHRemote/
 1. Github releases
     1. Edit and release the notes on https://github.com/sdl/ISHRemote/releases/
-    1. Start new release notes, under a new version number like `v0.10-beta`
+    1. Start new release notes, under a new version number like `v0.14-beta`
 1. Close version milestone on https://github.com/sdl/ISHRemote/milestone/
-
-## Testing and Debugging using Pester in Visual Studio 2015
-
-[src1](http://www.powershellmagazine.com/2014/03/12/get-started-with-pester-powershell-unit-testing-framework/) [src2](http://www.powershellmagazine.com/2014/03/27/testing-your-powershell-scripts-with-pester-assertions-and-more/) [src3](https://www.simple-talk.com/sysadmin/powershell/practical-powershell-unit-testing-getting-started/) [src4](https://github.com/pester/Pester/wiki
-Prerequisites)
-
-In `ISHRemote.PesterSetup.Debug.ps1` override the global variables used for tests. **Don't forget not to commit those custom values**.
-
-### Prerequisites
-
-1. Install or make sure you run Windows Management Framework v5, so Windows PowerShell v5 for Pester support, see https://msdn.microsoft.com/en-us/powershell/wmf/requirements
-1. Install [Powershell Tools for Visual Studio 2015](https://visualstudiogallery.msdn.microsoft.com/c9eb3ba8-0c59-4944-9a62-6eee37294597/view/Discussions/1)
-1. Install Pester and have it available in `%userprofile%\My Documents\WindowsPowerShell\Modules\Pester`
-
-    [Warning](https://www.nuget.org/packages/Pester/): Install `Pester` as Administrator, see  :  `Install-Package Pester -Source PSGallery` will eventually show you `Failed to load Pester module. The specified module 'Pester' was not loaded because no valid module 
-file was found in any module directory.` when running [Tests in Visual Studio](http://rostacik.net/2015/12/16/how-to-use-nuget-packages-even-with-powershell-projects-with-visual-studio-2015/)
-[Solution](https://writeabout.net/2016/01/01/visual-studio-github-powershell-pester/) is to copy content of `%ProgramFiles%\WindowsPowerShell\Modules\Pester\3.4.0" to "%userprofile%\My Documents\WindowsPowerShell\Modules\Pester`
-
-## Debugging using F5 In Visual Studio 2015
-[src](http://www.powershellmagazine.com/2014/04/08/basics-of-writing-a-powershell-module-with-c-part-2-debugging/)
-
-In the properties window, select Debug tab and select Start external program under Start Options. 
-Navigate to PowerShell.exe for the architecture of your project. In the Start Options -> 
-Command Line Arguments textbox, enter the parameters for the PowerShell executable that will 
-automatically load the module once it is compiled. The debugger starts always in the default 
-location where the DLL is generated. So, there is no need to specify the full path. In the case 
-of our module the option would be:
-
-    C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe
-	-noexit -command "&{ import-module .\ISHRemote.psm1 -verbose}"
-	OR
-	-noexit -command "&{ ..\..\Samples\Sample.Automate.EventMonitor.ps1}"
-	OR COMBINED
-	-noexit -command "&{ import-module .\ISHRemote.psm1 -verbose; ..\..\Samples\Sample.Automate.EventMonitor.ps1}"
- 
-Warning: If you get a security warning, run the above exact powershell.exe command using Run As Administrator, 
-then execute `Set-ExecutionPolicy Unrestricted`
 
 ## Debugging PowerShell in Visual Studio Code
 
@@ -191,12 +147,3 @@ Setting up your Visual Studio Code is explained on the internet, see [Scripting 
 - [Tyler Leonhardt - Visual Studio Code: deep dive into debugging your PowerShell scripts](https://www.youtube.com/watch?v=cSbIXmlkr8o)
 - [Writing Compiled PowerShell Cmdlets by Thomas Rayner](https://www.youtube.com/watch?v=O0lk92W799)
 
-## Static Code Analysis (experiment)
-
-1. Using `Docker Desktop` and `PowerShell Core 6` started `docker run -d --name sonarqube -p 9000:9000 sonarqube`
-1. Navigated to `http://localhost:9000/` going to through the new project wizard (admin, ISHRemote)
-1. Using `MSBuild Command Prompt for VS2015` triggered
-    1. `C:\TEMP\sonar\sonarscanner-msbuild\SonarScanner.MSBuild.exe begin /k:"ISHRemote" /d:sonar.host.url="http://localhost:9000" /d:sonar.login="9e96746fe7c2c8d11f6be0eed88cf3fb08c586d3"`
-    1. `MsBuild.exe /t:Rebuild`
-    1. `C:\TEMP\sonar\sonarscanner-msbuild\SonarScanner.MSBuild.exe end /d:sonar.login="9e96746fe7c2c8d11f6be0eed88cf3fb08c586d3"`
-1. Then look at the analysis :)

--- a/README.MD
+++ b/README.MD
@@ -120,10 +120,11 @@ synchronized with the code.
 
 ## Testing Standards
 
+Initial testing was based on Pester 3.4.0 which came as part of Windows 10/2016, to introduce support for PowerShell 7+ we switched to Pester 5+ ([#115](https://github.com/RWS/ISHRemote/issues/115)|[#132](https://github.com/RWS/ISHRemote/issues/132)). To force an upgrade from pre-packaged Pester 3.4.0, have a look at [Pester Installation](https://pester.dev/docs/introduction/installation), although on most systems it comes down to
+`Install-Module -Name Pester -Force -SkipPublisherCheck``.
 * Most Pester tests are acceptance test, enriched which some unit tests where possible.
-* Using a dot-sourced `ISHRemote.PesterSetup.ps1` include in all `*.Tests.ps1` to specify the variables (not initialization) consistently
-* Using the -Tag with "Create", "Read", "Update", "Delete" to allow [Pester grouping](See https://github.com/pester/Pester/wiki/Describe) Tags
-* Data initialization and breakdown are key but also time consuming. BeforeEach/AfterEach are run for every It block, so makes things slow.
+* Using a central `ISHRemote.PesterSetup.ps1` (with optional `ISHRemote.PesterSetup.Debug.ps1` override) in all `*.Tests.ps1` to specify the variables (not initialization) consistently
+* Data initialization and breakdown are key but also time consuming. After a test run, your system is left in its original state.
 
 # Coding Prerequisites and Best Practices
 

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/AddIshAnnotation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/AddIshAnnotation.Tests.ps1
@@ -1,290 +1,298 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshAnnotation"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshAnnotation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Add-IshAnnotation" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
-	$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-    Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	
-	#add topic
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent `
-					  | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic.IshRef)
-	$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMap
-	
-	#add publication
-    $ishPubMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata
+Describe "Add-IshAnnotation" -Tags "Create" {
+	BeforeAll {
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
+		$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+
+		Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		
+		#add topic
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectTopic = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent `
+						| Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+		#add map
+		$ditaMap = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic.IshRef)
+		$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectMap = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMap
+		
+		#add publication
+		$ishPubMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap.IshRef |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+		$ishObjectPub = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata
+	}
 	
 	Context "Add-IshAnnotation MetadataGroup" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [MetadataGroup] on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$ishAnnotationMetadata = Set-IshMetadataField -Name "FISHREVISIONID" -Level Annotation -Value $revisionId |
-		    Set-IshMetadataField -Name "FISHPUBLOGICALID" -Level Annotation -Value $ishObjectPub.IshRef |
-		    Set-IshMetadataField -Name "FISHPUBVERSION" -Level Annotation -Value $ishObjectPub.version_version_value |
-		    Set-IshMetadataField -Name "FISHPUBLANGUAGE" -Level Annotation -Value $ishObjectPub.fishpubsourcelanguages_version_value |
-		    Set-IshMetadataField -Name "FISHANNOTATIONSTATUS" -Level Annotation -ValueType Element -Value "VANNOTATIONSTATUSUNSHARED" |
-		    Set-IshMetadataField -Name "FISHANNOTATIONADDRESS" -Level Annotation -Value $annotationAddress |
-		    Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationText |
-		    Set-IshMetadataField -Name "FISHANNOTATIONCATEGORY" -Level Annotation -Value $annotationCategory |
-		    Set-IshMetadataField -Name "FISHANNOTATIONTYPE" -Level Annotation -Value $annotationType
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession -Metadata $ishAnnotationMetadata
-		
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [MetadataGroup] on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$ishAnnotationMetadata = Set-IshMetadataField -Name "FISHREVISIONID" -Level Annotation -Value $revisionId |
+				Set-IshMetadataField -Name "FISHPUBLOGICALID" -Level Annotation -Value $ishObjectPub.IshRef |
+				Set-IshMetadataField -Name "FISHPUBVERSION" -Level Annotation -Value $ishObjectPub.version_version_value |
+				Set-IshMetadataField -Name "FISHPUBLANGUAGE" -Level Annotation -Value $ishObjectPub.fishpubsourcelanguages_version_value |
+				Set-IshMetadataField -Name "FISHANNOTATIONSTATUS" -Level Annotation -ValueType Element -Value "VANNOTATIONSTATUSUNSHARED" |
+				Set-IshMetadataField -Name "FISHANNOTATIONADDRESS" -Level Annotation -Value $annotationAddress |
+				Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationText |
+				Set-IshMetadataField -Name "FISHANNOTATIONCATEGORY" -Level Annotation -Value $annotationCategory |
+				Set-IshMetadataField -Name "FISHANNOTATIONTYPE" -Level Annotation -Value $annotationType
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession -Metadata $ishAnnotationMetadata
+		}
 		It "GetType().Name" {
-			$ishAnnotation.GetType().Name | Should BeExactly "IshAnnotation"
+			$ishAnnotation.GetType().Name | Should -BeExactly "IshAnnotation"
 		}
 		It "ishAnnotation.IshField" {
-			$ishAnnotation.IshField | Should Not BeNullOrEmpty
+			$ishAnnotation.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishAnnotation.IshRef" {
-			$ishAnnotation.IshRef | Should Not BeNullOrEmpty
+			$ishAnnotation.IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishAnnotation.IshType" {
-			$ishAnnotation.IshType | Should Not BeNullOrEmpty
+			$ishAnnotation.IshType | Should -Not -BeNullOrEmpty
 		}
 		It "ishAnnotation.ObjectRef" {
-			$ishAnnotation.ObjectRef | Should Not BeNullOrEmpty
+			$ishAnnotation.ObjectRef | Should -Not -BeNullOrEmpty
 		}
         It "ishAnnotation PubLogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
         It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}
         It "ishAnnotation RevisionId" {
-			$ishAnnotation.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotation.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotation.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotation.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotation.fishannotationtext_annotation_value | Should BeExactly $annotationText
+			$ishAnnotation.fishannotationtext_annotation_value | Should -BeExactly $annotationText
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotation.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotation.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotation.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotation.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 		It "Metadata is null" {
-			{Add-IshAnnotation -IshSession $ishsession -Metadata $null} | Should Throw
+			{Add-IshAnnotation -IshSession $ishsession -Metadata $null} | Should -Throw
 		}
 	}
 
 	Context "Add-IshAnnotation ParametersGroup" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [ParametersGroup] on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-                            -LogicalId $ishObjectTopic.IshRef `
-                            -Version $ishObjectTopic.version_version_value `
-                            -Lng $ishObjectTopic.doclanguage `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress
-                               
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [ParametersGroup] on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-LogicalId $ishObjectTopic.IshRef `
+								-Version $ishObjectTopic.version_version_value `
+								-Lng $ishObjectTopic.doclanguage `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress
+        }
 		It "ishAnnotation RevisionId" {
-			$ishAnnotation.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotation.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
         It "ishAnnotation PubLogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
         It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation Version" {
-			$ishAnnotation.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotation.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}		
 		It "ishAnnotation Status" {
-			$ishAnnotation.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotation.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotation.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotation.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotation.fishannotationtext_annotation_value | Should BeExactly $annotationText
+			$ishAnnotation.fishannotationtext_annotation_value | Should -BeExactly $annotationText
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotation.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotation.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotation.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotation.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 	}
 	
 	Context "Add-IshAnnotation ParametersGroup override metadata matching parameters" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [ParametersGroup] on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		# this should not be overrided
-		$proposedChangeText = "Proposed change in this annotation"
-		
-		$metadataProvided = Set-IshMetadataField -Name "FISHREVISIONID" -Level Annotation -Value "GUID-123-REVISION-ID" |
-            Set-IshMetadataField -Name "FISHPUBLOGICALID" -Level Annotation -Value "GUID-123-PUBLICATION-ID" |
-            Set-IshMetadataField -Name "FISHPUBVERSION" -Level Annotation -Value "100" |
-            Set-IshMetadataField -Name "FISHPUBLANGUAGE" -Level Annotation -Value "aa" |
-            Set-IshMetadataField -Name "FISHANNOTATIONSTATUS" -Level Annotation -Value "Metadata status" |
-            Set-IshMetadataField -Name "FISHANNOTATIONADDRESS" -Level Annotation -Value "Metadata address" |
-            Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value "Metadata text" |
-            Set-IshMetadataField -Name "FISHANNOTATIONCATEGORY" -Level Annotation -Value "Metadata comment" |
-            Set-IshMetadataField -Name "FISHANNOTATIONTYPE" -Level Annotation -Value "Metadata type" |
-			Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
-		
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-                            -LogicalId $ishObjectTopic.IshRef `
-                            -Version $ishObjectTopic.version_version_value `
-                            -Lng $ishObjectTopic.doclanguage `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress `
-							-Metadata $metadataProvided
-                               
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [ParametersGroup] on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			# this should not be overrided
+			$proposedChangeText = "Proposed change in this annotation"
+			
+			$metadataProvided = Set-IshMetadataField -Name "FISHREVISIONID" -Level Annotation -Value "GUID-123-REVISION-ID" |
+				Set-IshMetadataField -Name "FISHPUBLOGICALID" -Level Annotation -Value "GUID-123-PUBLICATION-ID" |
+				Set-IshMetadataField -Name "FISHPUBVERSION" -Level Annotation -Value "100" |
+				Set-IshMetadataField -Name "FISHPUBLANGUAGE" -Level Annotation -Value "aa" |
+				Set-IshMetadataField -Name "FISHANNOTATIONSTATUS" -Level Annotation -Value "Metadata status" |
+				Set-IshMetadataField -Name "FISHANNOTATIONADDRESS" -Level Annotation -Value "Metadata address" |
+				Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value "Metadata text" |
+				Set-IshMetadataField -Name "FISHANNOTATIONCATEGORY" -Level Annotation -Value "Metadata comment" |
+				Set-IshMetadataField -Name "FISHANNOTATIONTYPE" -Level Annotation -Value "Metadata type" |
+				Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
+			
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-LogicalId $ishObjectTopic.IshRef `
+								-Version $ishObjectTopic.version_version_value `
+								-Lng $ishObjectTopic.doclanguage `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress `
+								-Metadata $metadataProvided
+		}                       
 		It "ishAnnotation Address" {
-			$ishAnnotation.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotation.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotation.fishannotationtext_annotation_value | Should BeExactly $annotationText
+			$ishAnnotation.fishannotationtext_annotation_value | Should -BeExactly $annotationText
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotation.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotation.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotation.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotation.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 		It "ishAnnotation Status" {
-			$ishAnnotation.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotation.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation PublogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
 		It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}
 		It "ishAnnotation RevisionId" {
-			$ishAnnotation.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotation.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation Version" {
-			$ishAnnotation.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotation.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}
 		It "ishAnnotation ProposedChngText" {
-			$ishAnnotation.fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChangeText
+			$ishAnnotation.fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChangeText
 		}
 	}	
 	
 	Context "Add-IshAnnotation IshObjectGroup" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [IshObjectGroup] on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-							-IshObject $ishObjectTopic `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress
-                               
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [IshObjectGroup] on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-IshObject $ishObjectTopic `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress
+		}                
 		It "ishAnnotation RevisionId" {
-			$ishAnnotation.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotation.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation Version" {
-			$ishAnnotation.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotation.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}		
 		It "ishAnnotation PublogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
 		It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}
 		It "ishAnnotation Status" {
-			$ishAnnotation.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotation.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotation.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotation.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotation.fishannotationtext_annotation_value | Should BeExactly $annotationText
+			$ishAnnotation.fishannotationtext_annotation_value | Should -BeExactly $annotationText
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotation.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotation.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotation.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotation.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 		It "IshObject is of invalid type (IshPublication)" {
 			{$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
@@ -297,371 +305,377 @@ Describe “Add-IshAnnotation" -Tags "Create" {
                             -Status $annotationStatus `
                             -Category $annotationCategory `
                             -Address $annotationAddress
-			} | Should Throw
+			} | Should -Throw
 		}
 	}
 
 	Context "Add-IshAnnotation IshObjectGroup override metadata matching parameters" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [IshObjectGroup] on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		# this should not be overrided
-		$proposedChangeText = "Proposed change in this annotation"
-		$metadataProvided = Set-IshMetadataField -Name "FISHREVISIONID" -Level Annotation -Value "GUID-123-REVISION-ID" | `
-            Set-IshMetadataField -Name "FISHPUBLOGICALID" -Level Annotation -Value "GUID-123-PUBLICATION-ID" |
-            Set-IshMetadataField -Name "FISHPUBVERSION" -Level Annotation -Value "100" |
-            Set-IshMetadataField -Name "FISHPUBLANGUAGE" -Level Annotation -Value "aa" |
-            Set-IshMetadataField -Name "FISHANNOTATIONSTATUS" -Level Annotation -Value "Metadata status" |
-            Set-IshMetadataField -Name "FISHANNOTATIONADDRESS" -Level Annotation -Value "Metadata address" |
-            Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value "Metadata text" |
-            Set-IshMetadataField -Name "FISHANNOTATIONCATEGORY" -Level Annotation -Value "Metadata comment" |
-            Set-IshMetadataField -Name "FISHANNOTATIONTYPE" -Level Annotation -Value "Metadata type" |
-			Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
-		
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-							-IshObject $ishObjectTopic `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress `
-							-Metadata $metadataProvided
-                               
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [IshObjectGroup] on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			# this should not be overrided
+			$proposedChangeText = "Proposed change in this annotation"
+			$metadataProvided = Set-IshMetadataField -Name "FISHREVISIONID" -Level Annotation -Value "GUID-123-REVISION-ID" | `
+				Set-IshMetadataField -Name "FISHPUBLOGICALID" -Level Annotation -Value "GUID-123-PUBLICATION-ID" |
+				Set-IshMetadataField -Name "FISHPUBVERSION" -Level Annotation -Value "100" |
+				Set-IshMetadataField -Name "FISHPUBLANGUAGE" -Level Annotation -Value "aa" |
+				Set-IshMetadataField -Name "FISHANNOTATIONSTATUS" -Level Annotation -Value "Metadata status" |
+				Set-IshMetadataField -Name "FISHANNOTATIONADDRESS" -Level Annotation -Value "Metadata address" |
+				Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value "Metadata text" |
+				Set-IshMetadataField -Name "FISHANNOTATIONCATEGORY" -Level Annotation -Value "Metadata comment" |
+				Set-IshMetadataField -Name "FISHANNOTATIONTYPE" -Level Annotation -Value "Metadata type" |
+				Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
+			
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-IshObject $ishObjectTopic `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress `
+								-Metadata $metadataProvided
+		}                       
 		It "ishAnnotation RevisionId" {
-			$ishAnnotation.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotation.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation Version" {
-			$ishAnnotation.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotation.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}	
 		It "ishAnnotation PublogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
 		It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}
 		It "ishAnnotation Status" {
-			$ishAnnotation.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotation.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotation.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotation.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotation.fishannotationtext_annotation_value | Should BeExactly $annotationText
+			$ishAnnotation.fishannotationtext_annotation_value | Should -BeExactly $annotationText
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotation.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotation.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotation.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotation.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 		It "ishAnnotation ProposedChngText" {
-			$ishAnnotation.fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChangeText
+			$ishAnnotation.fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChangeText
 		}
 	}
 	
 	Context "Add-IshAnnotation IshObjectGroup IshObject from pipeline" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [IshObjectGroup] pipeline on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		$ishAnnotation = $ishObjectTopic | Add-IshAnnotation -IshSession $ishsession `
-				                            -PubLogicalId $ishObjectPub.IshRef `
-				                            -PubVersion $ishObjectPub.version_version_value `
-                                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-				                            -Type $annotationType `
-				                            -Text $annotationText `
-				                            -Status $annotationStatus `
-				                            -Category $annotationCategory `
-				                            -Address $annotationAddress
-				                               
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [IshObjectGroup] pipeline on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			$ishAnnotation = $ishObjectTopic | Add-IshAnnotation -IshSession $ishsession `
+												-PubLogicalId $ishObjectPub.IshRef `
+												-PubVersion $ishObjectPub.version_version_value `
+												-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+												-Type $annotationType `
+												-Text $annotationText `
+												-Status $annotationStatus `
+												-Category $annotationCategory `
+												-Address $annotationAddress
+		}		                               
 		It "ishAnnotation RevisionId" {
-			$ishAnnotation.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotation.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotation.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation PublogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
 		It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}		
         It "ishAnnotation Version" {
-			$ishAnnotation.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotation.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotation.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}		
 		It "ishAnnotation Status" {
-			$ishAnnotation.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotation.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotation.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotation.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotation.fishannotationtext_annotation_value | Should BeExactly $annotationText
+			$ishAnnotation.fishannotationtext_annotation_value | Should -BeExactly $annotationText
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotation.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotation.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotation.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotation.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 	}
 
 	Context "Add-IshAnnotation IshAnnotationGroup" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationText = "by ISHRemote Pester [IshAnnotationGroup] on $timestamp"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		$proposedChangeText = "Proposed change in this annotation"
-		$metadata = Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
-		
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-							-IshObject $ishObjectTopic `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress `
-							-Metadata $metadata
-        
-		$proposedChangeTextUpdated = $proposedChangeText + "updated"
-		$annotationTextUpdated = $annotationText + "updated"
-		$ishAnnotation = $ishAnnotation | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
-										  Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
-		
-		$ishAnnotationUpdated = Add-IshAnnotation -IshSession $ishsession `
-												  -IshAnnotation $ishAnnotation
-		
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationText = "by ISHRemote Pester [IshAnnotationGroup] on $timestamp"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			$proposedChangeText = "Proposed change in this annotation"
+			$metadata = Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
+			
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-IshObject $ishObjectTopic `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress `
+								-Metadata $metadata
+			
+			$proposedChangeTextUpdated = $proposedChangeText + "updated"
+			$annotationTextUpdated = $annotationText + "updated"
+			$ishAnnotation = $ishAnnotation | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
+											Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
+			
+			$ishAnnotationUpdated = Add-IshAnnotation -IshSession $ishsession `
+													-IshAnnotation $ishAnnotation
+		}
 		It "ishAnnotation RevisionId" {
-			$ishAnnotationUpdated.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotationUpdated.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotationUpdated.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotationUpdated.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation PublogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
 		It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}
 		It "ishAnnotation Version" {
-			$ishAnnotationUpdated.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotationUpdated.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotationUpdated.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotationUpdated.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}		
 		It "ishAnnotation Status" {
-			$ishAnnotationUpdated.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotationUpdated.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotationUpdated.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotationUpdated.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotationUpdated.fishannotationtext_annotation_value | Should BeExactly $annotationTextUpdated
+			$ishAnnotationUpdated.fishannotationtext_annotation_value | Should -BeExactly $annotationTextUpdated
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotationUpdated.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotationUpdated.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotationUpdated.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotationUpdated.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 		It "ishAnnotation ProposedChngText" {
-			$ishAnnotationUpdated.fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChangeTextUpdated
+			$ishAnnotationUpdated.fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChangeTextUpdated
 		}
 	}
 
 	Context "Add-IshAnnotation IshAnnotationGroup array from pipeline" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationText = "by ISHRemote Pester [IshAnnotationGroup] pipeline on $timestamp"
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		$proposedChangeText = "Proposed change in this annotation"
-		$metadata = Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
-		$ishAnnotation1 = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-							-IshObject $ishObjectTopic `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress `
-							-Metadata $metadata
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationText = "by ISHRemote Pester [IshAnnotationGroup] pipeline on $timestamp"
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			$proposedChangeText = "Proposed change in this annotation"
+			$metadata = Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
+			$ishAnnotation1 = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-IshObject $ishObjectTopic `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress `
+								-Metadata $metadata
 
-		$ishAnnotation2 = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-							-IshObject $ishObjectTopic `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress `
-							-Metadata $metadata
+			$ishAnnotation2 = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-IshObject $ishObjectTopic `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress `
+								-Metadata $metadata
 
-		
-		$proposedChangeTextUpdated = $proposedChangeText + "updated"
-		$annotationTextUpdated = $annotationText + "updated"
-		$ishAnnotation1 = $ishAnnotation1 | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
-										    Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
-		$ishAnnotation2 = $ishAnnotation2 | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
-										    Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
-		
-		$ishAnnotationsUpdated = @($ishAnnotation1, $ishAnnotation2) | Add-IshAnnotation -IshSession $ishsession
+			
+			$proposedChangeTextUpdated = $proposedChangeText + "updated"
+			$annotationTextUpdated = $annotationText + "updated"
+			$ishAnnotation1 = $ishAnnotation1 | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
+												Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
+			$ishAnnotation2 = $ishAnnotation2 | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
+												Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
+			
+			$ishAnnotationsUpdated = @($ishAnnotation1, $ishAnnotation2) | Add-IshAnnotation -IshSession $ishsession
+		}
 		It "ishAnnotations array count" {
-				$ishAnnotationsUpdated.Count | Should BeExactly 2
+			$ishAnnotationsUpdated.Count | Should -BeExactly 2
 		}
 		
 		foreach($ishAnnotationUpdated in $ishAnnotationsUpdated)
 		{
 			It "ishAnnotation RevisionId" {
-				$ishAnnotationUpdated.fishrevisionid_annotation_value | Should BeExactly $revisionId
+				$ishAnnotationUpdated.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 			}
 			It "ishAnnotation LogicalId" {
-				$ishAnnotationUpdated.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+				$ishAnnotationUpdated.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 			}
 			It "ishAnnotation Version" {
-				$ishAnnotationUpdated.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+				$ishAnnotationUpdated.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 			}
 			It "ishAnnotation Lng" {
-				$ishAnnotationUpdated.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+				$ishAnnotationUpdated.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 			}	
 		    It "ishAnnotation PublogicalId" {
-			    $ishAnnotationUpdated.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			    $ishAnnotationUpdated.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		    }
 		    It "ishAnnotation PubVersion" {
-			    $ishAnnotationUpdated.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			    $ishAnnotationUpdated.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		    }
             It "ishAnnotation PubLng" {
-			    $ishAnnotationUpdated.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			    $ishAnnotationUpdated.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		    }	
 			It "ishAnnotation Status" {
-				$ishAnnotationUpdated.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+				$ishAnnotationUpdated.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 			}
 			It "ishAnnotation Address" {
-				$ishAnnotationUpdated.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+				$ishAnnotationUpdated.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 			}
 			It "ishAnnotation Text" {
-				$ishAnnotationUpdated.fishannotationtext_annotation_value | Should BeExactly $annotationTextUpdated
+				$ishAnnotationUpdated.fishannotationtext_annotation_value | Should -BeExactly $annotationTextUpdated
 			}
 			It "ishAnnotation Category" {
-				$ishAnnotationUpdated.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+				$ishAnnotationUpdated.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 			}
 			It "ishAnnotation Type" {
-				$ishAnnotationUpdated.fishannotationtype_annotation_value | Should BeExactly $annotationType
+				$ishAnnotationUpdated.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 			}
 			It "ishAnnotation ProposedChngText" {
-				$ishAnnotationUpdated.fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChangeTextUpdated
+				$ishAnnotationUpdated.fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChangeTextUpdated
 			}
 		}
 	}
 	
 	Context "Add-IshAnnotation IshAnnotationGroup single object from pipeline" {
-		$revisionId = $ishObjectTopic.ed
-		$annotationText = "by ISHRemote Pester [IshAnnotationGroup] pipeline on $timestamp"
-		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-		$proposedChangeText = "Proposed change in this annotation"
-		$metadata = Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
-		$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
-                            -PubLogicalId $ishObjectPub.IshRef `
-                            -PubVersion $ishObjectPub.version_version_value `
-                            -PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
-							-IshObject $ishObjectTopic `
-                            -Type $annotationType `
-                            -Text $annotationText `
-                            -Status $annotationStatus `
-                            -Category $annotationCategory `
-                            -Address $annotationAddress `
-							-Metadata $metadata
-		
-		$proposedChangeTextUpdated = $proposedChangeText + "updated"
-		$annotationTextUpdated = $annotationText + "updated"
-		$ishAnnotation = $ishAnnotation | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
-										  Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
-		
-		$ishAnnotationUpdated = $ishAnnotation | Add-IshAnnotation -IshSession $ishsession
-		
+		BeforeAll {
+			$revisionId = $ishObjectTopic.ed
+			$annotationText = "by ISHRemote Pester [IshAnnotationGroup] pipeline on $timestamp"
+			$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+			$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+			$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+			$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+			$proposedChangeText = "Proposed change in this annotation"
+			$metadata = Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeText
+			$ishAnnotation = Add-IshAnnotation -IshSession $ishsession `
+								-PubLogicalId $ishObjectPub.IshRef `
+								-PubVersion $ishObjectPub.version_version_value `
+								-PubLng $ishObjectPub.fishpubsourcelanguages_version_value `
+								-IshObject $ishObjectTopic `
+								-Type $annotationType `
+								-Text $annotationText `
+								-Status $annotationStatus `
+								-Category $annotationCategory `
+								-Address $annotationAddress `
+								-Metadata $metadata
+			
+			$proposedChangeTextUpdated = $proposedChangeText + "updated"
+			$annotationTextUpdated = $annotationText + "updated"
+			$ishAnnotation = $ishAnnotation | Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChangeTextUpdated |
+											Set-IshMetadataField -Name "FISHANNOTATIONTEXT" -Level Annotation -Value $annotationTextUpdated
+			
+			$ishAnnotationUpdated = $ishAnnotation | Add-IshAnnotation -IshSession $ishsession
+		}
 		It "ishAnnotation RevisionId" {
-			$ishAnnotationUpdated.fishrevisionid_annotation_value | Should BeExactly $revisionId
+			$ishAnnotationUpdated.fishrevisionid_annotation_value | Should -BeExactly $revisionId
 		}
 		It "ishAnnotation LogicalId" {
-			$ishAnnotationUpdated.fishcontentobjlogicalid_annotation_value | Should BeExactly $ishObjectTopic.IshRef
+			$ishAnnotationUpdated.fishcontentobjlogicalid_annotation_value | Should -BeExactly $ishObjectTopic.IshRef
 		}
 		It "ishAnnotation Version" {
-			$ishAnnotationUpdated.fishcontentobjversion_annotation_value | Should BeExactly $ishObjectTopic.version_version_value
+			$ishAnnotationUpdated.fishcontentobjversion_annotation_value | Should -BeExactly $ishObjectTopic.version_version_value
 		}
 		It "ishAnnotation Lng" {
-			$ishAnnotationUpdated.fishcontentobjlanguage_annotation_value | Should BeExactly $ishObjectTopic.doclanguage
+			$ishAnnotationUpdated.fishcontentobjlanguage_annotation_value | Should -BeExactly $ishObjectTopic.doclanguage
 		}	
 		It "ishAnnotation PublogicalId" {
-			$ishAnnotation.fishpublogicalid_annotation_value | Should BeExactly $ishObjectPub.IshRef
+			$ishAnnotation.fishpublogicalid_annotation_value | Should -BeExactly $ishObjectPub.IshRef
 		}
 		It "ishAnnotation PubVersion" {
-			$ishAnnotation.fishpubversion_annotation_value | Should BeExactly $ishObjectPub.version_version_value
+			$ishAnnotation.fishpubversion_annotation_value | Should -BeExactly $ishObjectPub.version_version_value
 		}
         It "ishAnnotation PubLng" {
-			$ishAnnotation.fishpublanguage_annotation_value | Should BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
+			$ishAnnotation.fishpublanguage_annotation_value | Should -BeExactly $ishObjectPub.fishpubsourcelanguages_version_value
 		}	
 		It "ishAnnotation Status" {
-			$ishAnnotationUpdated.fishannotationstatus_annotation_value | Should BeExactly $annotationStatus
+			$ishAnnotationUpdated.fishannotationstatus_annotation_value | Should -BeExactly $annotationStatus
 		}
 		It "ishAnnotation Address" {
-			$ishAnnotationUpdated.fishannotationaddress_annotation_value | Should BeExactly $annotationAddress
+			$ishAnnotationUpdated.fishannotationaddress_annotation_value | Should -BeExactly $annotationAddress
 		}
 		It "ishAnnotation Text" {
-			$ishAnnotationUpdated.fishannotationtext_annotation_value | Should BeExactly $annotationTextUpdated
+			$ishAnnotationUpdated.fishannotationtext_annotation_value | Should -BeExactly $annotationTextUpdated
 		}
 		It "ishAnnotation Category" {
-			$ishAnnotationUpdated.fishannotationcategory_annotation_value | Should BeExactly $annotationCategory
+			$ishAnnotationUpdated.fishannotationcategory_annotation_value | Should -BeExactly $annotationCategory
 		}
 		It "ishAnnotation Type" {
-			$ishAnnotationUpdated.fishannotationtype_annotation_value | Should BeExactly $annotationType
+			$ishAnnotationUpdated.fishannotationtype_annotation_value | Should -BeExactly $annotationType
 		}
 		It "ishAnnotation ProposedChngText" {
-			$ishAnnotationUpdated.fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChangeTextUpdated
+			$ishAnnotationUpdated.fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChangeTextUpdated
 		}
 	}
 }
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	$publicationOutputs = Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse |
                           Where-Object -Property IshFolderType -EQ -Value "ISHPublication" | 

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/FindIshAnnotation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/FindIshAnnotation.Tests.ps1
@@ -1,89 +1,92 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Find-IshAnnotation"
-try {
+BeforeAll {
+	$cmdletName = "Find-IshAnnotation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Find-IshAnnotation" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
-	$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-    Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Find-IshAnnotation" -Tags "Create" {
+	BeforeAll {
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
+		$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
 
-	## Publication 1 (2 annotations)
-    #add topic
-	$ishTopicMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						 Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						 Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic1 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata1 -FileContent $ditaTopicFileContent |
-	                   Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap1 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic1.IshRef)
-	$ishMapMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				       Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                   Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata1 -Edt "EDTXML" -FileContent $ditaMap1
-	
-	#add publication
-    $ishPubMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap1.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub1 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata1
+		Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
-	## Publication 2 (1 annotation with 2 replies)
-    #add topic
-	$ishTopicMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic 2 $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic2 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata2 -FileContent $ditaTopicFileContent |
-					   Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap2 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic2.IshRef)
-	$ishMapMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata2 -Edt "EDTXML" -FileContent $ditaMap2
-	
-	#add publication
-    $ishPubMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap2.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub2 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata2
-	
-    #add annotations
-	$revisionId = $ishObjectTopic.ed
-	$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-	$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-	$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-	$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-	$proposedChngText = "My proposed change text"
+		## Publication 1 (2 annotations)
+		#add topic
+		$ishTopicMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+							Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectTopic1 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata1 -FileContent $ditaTopicFileContent |
+						Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+		#add map
+		$ditaMap1 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic1.IshRef)
+		$ishMapMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectMap1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata1 -Edt "EDTXML" -FileContent $ditaMap1
+		
+		#add publication
+		$ishPubMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap1.IshRef |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+		$ishObjectPub1 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata1
 
-	# Add annotations - Publication 1
-    $annotationTextCustom1 = "by #1 ISHRemote Pester on $timestamp"
-    $annotationTextCustom2 = "by #2 ISHRemote Pester on $timestamp"
-	$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
-    $ishAnnotation1P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-	$ishAnnotation2P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom2 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-    $annotationIdsP1 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef)
+		## Publication 2 (1 annotation with 2 replies)
+		#add topic
+		$ishTopicMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic 2 $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectTopic2 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata2 -FileContent $ditaTopicFileContent |
+						Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+		#add map
+		$ditaMap2 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic2.IshRef)
+		$ishMapMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectMap2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata2 -Edt "EDTXML" -FileContent $ditaMap2
+		
+		#add publication
+		$ishPubMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap2.IshRef |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+		$ishObjectPub2 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata2
+		
+		#add annotations
+		$revisionId = $ishObjectTopic.ed
+		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+		$proposedChngText = "My proposed change text"
 
-    # Add annotations with replies - Publication 2
-	$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
-    $annotationText = "by ISHRemote Pester on $timestamp"
-	$ishAnnotation1P2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub2.IshRef -PubVersion $ishObjectPub2.version_version_value -PubLng $ishObjectPub2.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic2.IshRef -Version $ishObjectTopic2.version_version_value -Lng $ishObjectTopic2.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotation1P2.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$replyRef1 = $ishsession.Annotation25.CreateReply($ishAnnotation1P2.IshRef, $strMetadataReply)
-	$replyRef2 = $ishsession.Annotation25.CreateReply($ishAnnotation1P2.IshRef, $strMetadataReply)
-	$replyIdsP2 = @($replyRef1, $replyRef2)
-	
+		# Add annotations - Publication 1
+		$annotationTextCustom1 = "by #1 ISHRemote Pester on $timestamp"
+		$annotationTextCustom2 = "by #2 ISHRemote Pester on $timestamp"
+		$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
+		$ishAnnotation1P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+		$ishAnnotation2P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom2 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+		$annotationIdsP1 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef)
+
+		# Add annotations with replies - Publication 2
+		$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
+		$annotationText = "by ISHRemote Pester on $timestamp"
+		$ishAnnotation1P2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub2.IshRef -PubVersion $ishObjectPub2.version_version_value -PubLng $ishObjectPub2.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic2.IshRef -Version $ishObjectTopic2.version_version_value -Lng $ishObjectTopic2.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotation1P2.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$replyRef1 = $ishsession.Annotation25.CreateReply($ishAnnotation1P2.IshRef, $strMetadataReply)
+		$replyRef2 = $ishsession.Annotation25.CreateReply($ishAnnotation1P2.IshRef, $strMetadataReply)
+		$replyIdsP2 = @($replyRef1, $replyRef2)
+	}
     Context "Find-IshAnnotation" {
 		It "Find all annotations from Publication1 with RequestedMetadata" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTATIONREPLIES" -Level Annotation
@@ -91,19 +94,18 @@ Describe “Find-IshAnnotation" -Tags "Create" {
             $ishAnnotations = Find-IshAnnotation -IshSession $ishsession `
                                                 -RequestedMetadata $requestedMetadata `
                                                 -MetadataFilter $metadataFilter
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
 		}
 		It "Find all annotations from Publication1 without RequestedMetadata" {
             $metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Name FISHPUBLOGICALID -Level Annotation -FilterOperator Equal -Value $ishObjectPub1.IshRef
             $ishAnnotations = Find-IshAnnotation -IshSession $ishsession `
                                                  -MetadataFilter $metadataFilter
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
 		}
-
 		It "Find only 1 annotation from Publication1" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTATIONREPLIES" -Level Annotation
             $metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Name FISHPUBLOGICALID -Level Annotation -FilterOperator Equal -Value $ishObjectPub1.IshRef |
@@ -111,23 +113,22 @@ Describe “Find-IshAnnotation" -Tags "Create" {
             $ishAnnotations = Find-IshAnnotation -IshSession $ishsession `
                                                 -RequestedMetadata $requestedMetadata `
                                                 -MetadataFilter $metadataFilter
-			$ishAnnotations.Count | Should BeExactly 1
-            $ishAnnotation1P1.IshRef | Should BeExactly $ishAnnotations.IshRef
+			$ishAnnotations.Count | Should -BeExactly 1
+            $ishAnnotation1P1.IshRef | Should -BeExactly $ishAnnotations.IshRef
 		}
-
         It "Find annotations and replies from Publication2 without RequestedMetadata" {
             $metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Name FISHPUBLOGICALID -Level Annotation -FilterOperator Equal -Value $ishObjectPub2.IshRef
             $ishAnnotations = Find-IshAnnotation -IshSession $ishsession `
                                                  -MetadataFilter $metadataFilter
-			$ishAnnotations.Count | Should BeExactly 2
-            $replyIdsP2 -contains $ishAnnotations[0].ReplyRef | Should Be $true
-            $replyIdsP2 -contains $ishAnnotations[1].ReplyRef | Should Be $true
+			$ishAnnotations.Count | Should -BeExactly 2
+            $replyIdsP2 -contains $ishAnnotations[0].ReplyRef | Should -Be $true
+            $replyIdsP2 -contains $ishAnnotations[1].ReplyRef | Should -Be $true
 		}
     }
 }
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	$publicationOutputs = Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse |
                           Where-Object -Property IshFolderType -EQ -Value "ISHPublication" | 

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/GetIshAnnotation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/GetIshAnnotation.Tests.ps1
@@ -1,150 +1,153 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshAnnotation"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshAnnotation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshAnnotation" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
-	$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-    Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Get-IshAnnotation" -Tags "Create" {
+    BeforeAll {
+        $ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
+        $folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+        $folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+        $ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
+        $readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
 
-    # add image object
-	$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Image $timestamp" |
-				        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	    			    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$tempFilePath = (New-TemporaryFile).FullName
-	Add-Type -AssemblyName "System.Drawing"
-	$bmp = New-Object -TypeName System.Drawing.Bitmap(100,100)
-	for ($i = 0; $i -lt 100; $i++)
-	{
-		for ($j = 0; $j -lt 100; $j++)
-		{
-			$bmp.SetPixel($i, $j, 'Red')
-		}
-	}
-	$bmp.Save($tempFilePath, [System.Drawing.Imaging.ImageFormat]::Jpeg)
-	$ishObjectImage = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderImage -IshType ISHIllustration -LogicalId "MYOWNGENERATEDLOGICALIDIMAGE" -Version '1' -Lng $ishLng -Resolution $ishResolution -Metadata $ishImageMetadata -Edt "EDTJPEG" -FilePath $tempFilePath
+        Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+        $global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+        $ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+        $ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+        $ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+        $ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
-	## Publication 1
-    #add topic
-	$ishTopicMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						 Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						 Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic1 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata1 -FileContent $ditaTopicFileContent `
-					  | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap1 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic1.IshRef)
-	$ishMapMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				       Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                   Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata1 -Edt "EDTXML" -FileContent $ditaMap1
-	
-	#add publication
-    $ishPubMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap1.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub1 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata1
+        # add image object
+        $ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Image $timestamp" |
+                            Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                            Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $tempFilePath = (New-TemporaryFile).FullName
+        Add-Type -AssemblyName "System.Drawing"
+        $bmp = New-Object -TypeName System.Drawing.Bitmap(100,100)
+        for ($i = 0; $i -lt 100; $i++)
+        {
+            for ($j = 0; $j -lt 100; $j++)
+            {
+                $bmp.SetPixel($i, $j, 'Red')
+            }
+        }
+        $bmp.Save($tempFilePath, [System.Drawing.Imaging.ImageFormat]::Jpeg)
+        $ishObjectImage = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderImage -IshType ISHIllustration -LogicalId "MYOWNGENERATEDLOGICALIDIMAGE" -Version '1' -Lng $ishLng -Resolution $ishResolution -Metadata $ishImageMetadata -Edt "EDTJPEG" -FilePath $tempFilePath
 
-	## Publication 2
-    #add topic
-	$ishTopicMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic 2 $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic2 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata2 -FileContent $ditaTopicFileContent `
-					  | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap2 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic2.IshRef)
-	$ishMapMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata2 -Edt "EDTXML" -FileContent $ditaMap2
-	
-	#add publication
-    $ishPubMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap2.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub2 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata2
+        ## Publication 1
+        #add topic
+        $ishTopicMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+                            Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                            Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $ishObjectTopic1 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata1 -FileContent $ditaTopicFileContent `
+                        | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+        #add map
+        $ditaMap1 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic1.IshRef)
+        $ishMapMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $ishObjectMap1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata1 -Edt "EDTXML" -FileContent $ditaMap1
+        
+        #add publication
+        $ishPubMetadata1 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap1.IshRef |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+        $ishObjectPub1 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata1
 
-	## Publication 3 (annotation has replies)
-    #add topic
-	$ishTopicMetadata3 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic 3 $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic3 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata3 -FileContent $ditaTopicFileContent `
-					  | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap3 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic3.IshRef)
-	$ishMapMetadata3 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata3 -Edt "EDTXML" -FileContent $ditaMap3
-	
-	#add publication
-    $ishPubMetadata3 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap3.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub3 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata3
-	
-    #add annotations
-	$revisionId = $ishObjectTopic.ed
-	$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-    $annotationTextCustom1 = "by #1 ISHRemote Pester on $timestamp"
-    $annotationTextCustom2 = "by #2 ISHRemote Pester on $timestamp"
-    $annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-	$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-	$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-	$proposedChngText = "My proposed change text"
+        ## Publication 2
+        #add topic
+        $ishTopicMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic 2 $timestamp" |
+                                Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                                Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $ishObjectTopic2 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata2 -FileContent $ditaTopicFileContent `
+                        | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+        #add map
+        $ditaMap2 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic2.IshRef)
+        $ishMapMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $ishObjectMap2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata2 -Edt "EDTXML" -FileContent $ditaMap2
+        
+        #add publication
+        $ishPubMetadata2 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap2.IshRef |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+        $ishObjectPub2 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata2
 
-	# Add annotations - Publication 1
-	$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
-    $ishAnnotation1P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-	$ishAnnotation2P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom2 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-    $annotationIdsP1 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef)
-	
-    # Add annotations - Publication 2
-	$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
-    $ishAnnotation1P2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub2.IshRef -PubVersion $ishObjectPub2.version_version_value -PubLng $ishObjectPub2.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic2.IshRef -Version $ishObjectTopic2.version_version_value -Lng $ishObjectTopic2.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-	$ishAnnotation2P2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub2.IshRef -PubVersion $ishObjectPub2.version_version_value -PubLng $ishObjectPub2.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic2.IshRef -Version $ishObjectTopic2.version_version_value -Lng $ishObjectTopic2.doclanguage -Type $annotationType -Text $annotationTextCustom2 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+        ## Publication 3 (annotation has replies)
+        #add topic
+        $ishTopicMetadata3 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic 3 $timestamp" |
+                                Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                                Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $ishObjectTopic3 = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata3 -FileContent $ditaTopicFileContent `
+                        | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+        #add map
+        $ditaMap3 = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic3.IshRef)
+        $ishMapMetadata3 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+        $ishObjectMap3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata3 -Edt "EDTXML" -FileContent $ditaMap3
+        
+        #add publication
+        $ishPubMetadata3 = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap3.IshRef |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+                        Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+        $ishObjectPub3 = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata3
+        
+        #add annotations
+        $revisionId = $ishObjectTopic.ed
+        $annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+        $annotationTextCustom1 = "by #1 ISHRemote Pester on $timestamp"
+        $annotationTextCustom2 = "by #2 ISHRemote Pester on $timestamp"
+        $annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+        $annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+        $annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+        $proposedChngText = "My proposed change text"
 
-    # Add annotations with replies - Publication 3
-	$metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
-    $ishAnnotation1P3 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub3.IshRef -PubVersion $ishObjectPub3.version_version_value -PubLng $ishObjectPub3.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic3.IshRef -Version $ishObjectTopic3.version_version_value -Lng $ishObjectTopic3.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotation1P3.IshRef)</ishfield></ishfields>"
-	$replyRef1 = $ishsession.Annotation25.CreateReply($ishAnnotation1P3.IshRef, $strMetadataReply)
-	$replyRef2 = $ishsession.Annotation25.CreateReply($ishAnnotation1P3.IshRef, $strMetadataReply)
-	$replyIdsP3 = @($replyRef1, $replyRef2)
-	
-    # array with all added annotations
-    $annotationIdsP1P2 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef,$ishAnnotation1P2.IshRef, $ishAnnotation2P2.IshRef)
-	$annotationIdsP1P2P3 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef,$ishAnnotation1P2.IshRef, $ishAnnotation2P2.IshRef, $ishAnnotation1P3.IshRef)
-	
+        # Add annotations - Publication 1
+        $metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
+        $ishAnnotation1P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+        $ishAnnotation2P1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub1.IshRef -PubVersion $ishObjectPub1.version_version_value -PubLng $ishObjectPub1.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic1.IshRef -Version $ishObjectTopic1.version_version_value -Lng $ishObjectTopic1.doclanguage -Type $annotationType -Text $annotationTextCustom2 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+        $annotationIdsP1 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef)
+        
+        # Add annotations - Publication 2
+        $metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
+        $ishAnnotation1P2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub2.IshRef -PubVersion $ishObjectPub2.version_version_value -PubLng $ishObjectPub2.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic2.IshRef -Version $ishObjectTopic2.version_version_value -Lng $ishObjectTopic2.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+        $ishAnnotation2P2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub2.IshRef -PubVersion $ishObjectPub2.version_version_value -PubLng $ishObjectPub2.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic2.IshRef -Version $ishObjectTopic2.version_version_value -Lng $ishObjectTopic2.doclanguage -Type $annotationType -Text $annotationTextCustom2 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+
+        # Add annotations with replies - Publication 3
+        $metadata =	Set-IshMetadataField -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation -Value $proposedChngText
+        $ishAnnotation1P3 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub3.IshRef -PubVersion $ishObjectPub3.version_version_value -PubLng $ishObjectPub3.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic3.IshRef -Version $ishObjectTopic3.version_version_value -Lng $ishObjectTopic3.doclanguage -Type $annotationType -Text $annotationTextCustom1 -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress -Metadata $metadata
+        $strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotation1P3.IshRef)</ishfield></ishfields>"
+        $replyRef1 = $ishsession.Annotation25.CreateReply($ishAnnotation1P3.IshRef, $strMetadataReply)
+        $replyRef2 = $ishsession.Annotation25.CreateReply($ishAnnotation1P3.IshRef, $strMetadataReply)
+        $replyIdsP3 = @($replyRef1, $replyRef2)
+        
+        # array with all added annotations
+        $annotationIdsP1P2 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef,$ishAnnotation1P2.IshRef, $ishAnnotation2P2.IshRef)
+        $annotationIdsP1P2P3 = @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef,$ishAnnotation1P2.IshRef, $ishAnnotation2P2.IshRef, $ishAnnotation1P3.IshRef)
+    }	
     Context "Get-IshAnnotation ParametersGroup" {
 		It "Parameter AnnotationId is an empty array" {
-			{Get-IshAnnotation -IshSession $ishsession -AnnotationId @()} | Should Throw
+			{Get-IshAnnotation -IshSession $ishsession -AnnotationId @()} | Should -Throw
 		}
 		It "Parameter AnnotationId contains non-existing Ids" {
 			$ishAnnotations = Get-IshAnnotation -IshSession $ishsession -AnnotationId @("GUID-NON-EXISTING1","GUID-NON-EXISTING1")
-            $ishAnnotations.Count | Should Be 0
-            $ishAnnotations | Should Be $null
+            $ishAnnotations.Count | Should -Be 0
+            $ishAnnotations | Should -Be $null
 		}
 		It "Get without RequestedMetadata and MetadataFilter" {
 			$ishAnnotations = Get-IshAnnotation -IshSession $ishsession -AnnotationId @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef)
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
 		}
 		It "Get with RequstedMetadata and without MetadataFilter" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTATIONREPLIES" -Level Annotation
@@ -154,11 +157,11 @@ Describe “Get-IshAnnotation" -Tags "Create" {
             $repliesValue1 = Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTATIONREPLIES" -Level Annotation -ValueType Value
             $repliesValue2 = Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTATIONREPLIES" -Level Annotation -ValueType Value
 
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
-            $repliesValue1 | Should Be ""
-            $repliesValue2 | Should Be ""
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
+            $repliesValue1 | Should -Be ""
+            $repliesValue2 | Should -Be ""
 		}
 		It "Get with RequstedMetadata and with MetadataFilter" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTATIONREPLIES" -Level Annotation
@@ -167,94 +170,94 @@ Describe “Get-IshAnnotation" -Tags "Create" {
                                                 -AnnotationId @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef) `
                                                 -RequestedMetadata $requestedMetadata `
                                                 -MetadataFilter $metadataFilter
-			$ishAnnotations.Count | Should BeExactly 1
+			$ishAnnotations.Count | Should -BeExactly 1
 
             $metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Name FISHANNOTATIONTEXT -Level Annotation -FilterOperator Like -Value "by%"
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession `
                                                 -AnnotationId @($ishAnnotation1P1.IshRef, $ishAnnotation2P1.IshRef) `
                                                 -RequestedMetadata $requestedMetadata `
                                                 -MetadataFilter $metadataFilter
-			$ishAnnotations.Count | Should BeExactly 2
+			$ishAnnotations.Count | Should -BeExactly 2
 		}
     }
 
     Context "Get-IshAnnotation IshObjectGroup" {
         It "Get for Map object" {
             $ishAnnotations = $ishObjectMap1 | Get-IshAnnotation -IshSession $ishsession
-            $ishAnnotations.Count | Should BeExactly 0
+            $ishAnnotations.Count | Should -BeExactly 0
         }
         It "Get for Image object" {
             $ishAnnotations =  $ishObjectImage | Get-IshAnnotation -IshSession $ishsession
-            $ishAnnotations.Count | Should BeExactly 0
+            $ishAnnotations.Count | Should -BeExactly 0
         }
         It "Get for Publication1 without RequestedMetadata" {
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshObject $ishObjectPub1
-            $ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
+            $ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
         }
         It "Get for Publication1 with RequestedMetadata" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshObject $ishObjectPub1 -RequestedMetadata $requestedMetadata
-            $ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
-            $ishAnnotations[0].fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChngText
-            $ishAnnotations[1].fishannotproposedchngtxt_annotation_value | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+            $ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
+            $ishAnnotations[0].fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChngText
+            $ishAnnotations[1].fishannotproposedchngtxt_annotation_value | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
         }
          It "Get for Publication1 with RequestedMetadata, Pipeline" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = $ishObjectPub1 | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-            $ishAnnotations.Count | Should BeExactly 2
-            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+            $ishAnnotations.Count | Should -BeExactly 2
+            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
         }
          It "Get for Publication1,Publication2 with RequestedMetadata, Pipeline" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = @($ishObjectPub1, $ishObjectPub2) | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-            $ishAnnotations.Count | Should BeExactly 4
-            $annotationIdsP1P2 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1P2 -contains $ishAnnotations[1].IshRef | Should Be $true
-            $annotationIdsP1P2 -contains $ishAnnotations[2].IshRef | Should Be $true
-            $annotationIdsP1P2 -contains $ishAnnotations[3].IshRef | Should Be $true
+            $ishAnnotations.Count | Should -BeExactly 4
+            $annotationIdsP1P2 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1P2 -contains $ishAnnotations[1].IshRef | Should -Be $true
+            $annotationIdsP1P2 -contains $ishAnnotations[2].IshRef | Should -Be $true
+            $annotationIdsP1P2 -contains $ishAnnotations[3].IshRef | Should -Be $true
         }
         It "Get for Topic without RequestedMetadata" {
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshObject $ishObjectTopic1
-            $ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
+            $ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
         }
         It "Get for Topic with RequestedMetadata" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshObject $ishObjectTopic1 -RequestedMetadata $requestedMetadata
-            $ishAnnotations.Count | Should BeExactly 2
-            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+            $ishAnnotations.Count | Should -BeExactly 2
+            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
         }
         It "Get for Topic with RequestedMetadata, Pipeline" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = $ishObjectTopic1 | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-            $ishAnnotations.Count | Should BeExactly 2
-            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+            $ishAnnotations.Count | Should -BeExactly 2
+            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
         }
         It "Get for Topic1, Topic2 with RequestedMetadata, Pipeline" {
             $requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = @($ishObjectTopic1, $ishObjectTopic2) | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-            $ishAnnotations.Count | Should BeExactly 4
-            $annotationIdsP1P2 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1P2 -contains $ishAnnotations[1].IshRef | Should Be $true
-            $annotationIdsP1P2 -contains $ishAnnotations[2].IshRef | Should Be $true
-            $annotationIdsP1P2 -contains $ishAnnotations[3].IshRef | Should Be $true
+            $ishAnnotations.Count | Should -BeExactly 4
+            $annotationIdsP1P2 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1P2 -contains $ishAnnotations[1].IshRef | Should -Be $true
+            $annotationIdsP1P2 -contains $ishAnnotations[2].IshRef | Should -Be $true
+            $annotationIdsP1P2 -contains $ishAnnotations[3].IshRef | Should -Be $true
         }
 		It "Get for Publication3 where annotation has 2 replies"{
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
 			$ishAnnotations = $ishObjectPub3 | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-			$ishAnnotations.Count | Should BeExactly 2
-			$replyIdsP3 -contains $ishAnnotations[0].ReplyRef | Should Be $true 
-			$replyIdsP3 -contains $ishAnnotations[1].ReplyRef | Should Be $true 
+			$ishAnnotations.Count | Should -BeExactly 2
+			$replyIdsP3 -contains $ishAnnotations[0].ReplyRef | Should -Be $true 
+			$replyIdsP3 -contains $ishAnnotations[1].ReplyRef | Should -Be $true 
 		}
     }
     Context "Get-IshAnnotation IshObjectGroup mixed IshObjects from Get-IshFolderContent" {
@@ -262,10 +265,10 @@ Describe “Get-IshAnnotation" -Tags "Create" {
             $ishAnnotations = Get-IshFolder -IshSession $ishsession -FolderId ($global:ishAnnotationCmdlet.IshFolderRef) -Recurse |
                               Get-IshFolderContent -IshSession $ishsession |
                               Get-IshAnnotation -IshSession $ishsession
-            $ishAnnotations.Count | Should BeExactly 6
+            $ishAnnotations.Count | Should -BeExactly 6
 			foreach($ishAnnotation in $ishAnnotations)
 			{
-				$annotationIdsP1P2P3 -contains $ishAnnotation.IshRef | Should Be $true
+				$annotationIdsP1P2P3 -contains $ishAnnotation.IshRef | Should -Be $true
 			}
          }
 
@@ -273,63 +276,63 @@ Describe “Get-IshAnnotation" -Tags "Create" {
             $ishObjects = Get-Ishfolder -IshSession $ishsession -FolderId ($global:ishAnnotationCmdlet.IshFolderRef) -Recurse |
                           Get-IshFolderContent -IshSession $ishsession                              
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshObject $ishObjects 
-            $ishAnnotations.Count | Should BeExactly 6
+            $ishAnnotations.Count | Should -BeExactly 6
 			foreach($ishAnnotation in $ishAnnotations)
 			{
-				$annotationIdsP1P2P3 -contains $ishAnnotation.IshRef | Should Be $true
+				$annotationIdsP1P2P3 -contains $ishAnnotation.IshRef | Should -Be $true
 			}
         }
     }
     Context "Get-IshAnnotation IshAnnotationGroup" {
         It "Get array of IshAnnotation without RequestedMetadata" {
 			$ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshAnnotation @($ishAnnotation1P1, $ishAnnotation2P1)
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
 		}
         It "Get array of IshAnnotation with RequestedMetadata" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshAnnotation @($ishAnnotation1P1, $ishAnnotation2P1) -RequestedMetadata $requestedMetadata
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
-            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
+            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
 		}
         It "Get single IshAnnotation without RequestedMetadata" {
 			$ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshAnnotation $ishAnnotation1P1
-			$ishAnnotations.Count | Should BeExactly 1
-            $ishAnnotations.IshRef | Should BeExactly $ishAnnotation1P1.IshRef
+			$ishAnnotations.Count | Should -BeExactly 1
+            $ishAnnotations.IshRef | Should -BeExactly $ishAnnotation1P1.IshRef
 		}
         It "Get single IshAnnotation with RequestedMetadata" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = Get-IshAnnotation -IshSession $ishsession -IshAnnotation $ishAnnotation1P1 -RequestedMetadata $requestedMetadata
-			$ishAnnotations.Count | Should BeExactly 1
-            $ishAnnotations.IshRef | Should BeExactly $ishAnnotation1P1.IshRef
-            Get-IshMetadataField -IshObject $ishAnnotations -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+			$ishAnnotations.Count | Should -BeExactly 1
+            $ishAnnotations.IshRef | Should -BeExactly $ishAnnotation1P1.IshRef
+            Get-IshMetadataField -IshObject $ishAnnotations -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
 		}
 
         It "Get with RequestedMetadata, pipeline single object" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = $ishAnnotation1P1 | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-			$ishAnnotations.Count | Should BeExactly 1
-            $annotationIdsP1 -contains $ishAnnotations.IshRef | Should Be $true
-            Get-IshMetadataField -IshObject $ishAnnotations -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+			$ishAnnotations.Count | Should -BeExactly 1
+            $annotationIdsP1 -contains $ishAnnotations.IshRef | Should -Be $true
+            Get-IshMetadataField -IshObject $ishAnnotations -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
         }
         It "Get with RequestedMetadata, pipeline array" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation
             $ishAnnotations = @($ishAnnotation1P1, $ishAnnotation2P1) | Get-IshAnnotation -IshSession $ishsession -RequestedMetadata $requestedMetadata
-			$ishAnnotations.Count | Should BeExactly 2
-            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should Be $true
-            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should Be $true
-            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
-            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should BeExactly $proposedChngText
+			$ishAnnotations.Count | Should -BeExactly 2
+            $annotationIdsP1 -contains $ishAnnotations[0].IshRef | Should -Be $true
+            $annotationIdsP1 -contains $ishAnnotations[1].IshRef | Should -Be $true
+            Get-IshMetadataField -IshObject $ishAnnotations[0] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
+            Get-IshMetadataField -IshObject $ishAnnotations[1] -Name "FISHANNOTPROPOSEDCHNGTXT" -Level Annotation | Should -BeExactly $proposedChngText
         }
     }
 }
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
     $publicationOutputs = Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse |
                           Where-Object -Property IshFolderType -EQ -Value "ISHPublication" | 

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/RemoveIshAnnotation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Annotation/RemoveIshAnnotation.Tests.ps1
@@ -1,165 +1,168 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Remove-IshAnnotation"
-try {
+BeforeAll {
+	$cmdletName = "Remove-IshAnnotation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Remove-IshAnnotation" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
-	$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-    Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	
-	#add topic
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopic = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent `
-					  | Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
-	#add map
-	$ditaMap = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic.IshRef)
-	$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMap
-	
-	#add publication
-    $ishPubMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata
-	
-    #add annotations
-	$revisionId = $ishObjectTopic.ed
-	$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
-	$annotationText = "by ISHRemote Pester on $timestamp"
-	$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
-	$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
-	$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
-	
-	# Add annotations - ParametersGroup
-	$ishAnnotationPG1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationPGWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationPGWithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPGWithReplies.IshRef, $strMetadataReply)
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPGWithReplies.IshRef, $strMetadataReply)
-	
-	# Add annotations - IshAnnotationGroup
-	$ishAnnotationIAG1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationIAGWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGWithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGWithReplies.IshRef, $strMetadataReply)
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGWithReplies.IshRef, $strMetadataReply)
-	
-	# annotations for mixed test (with and without replies)
-	$ishAnnotationIAGMixed1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationIAGMixed2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationIAGMixedWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGWithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$ishsession.Annotation25.CreateReply($ishAnnotationIAGMixedWithReplies.IshRef, $strMetadataReply)
-	$ishsession.Annotation25.CreateReply($ishAnnotationIAGMixedWithReplies.IshRef, $strMetadataReply)
-	
-	# Add annotations - IshAnnotationGroup (pipeline)
-	$ishAnnotationIAGpipeline2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationIAGpipeline1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationIAGpipeline1WithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGpipeline1WithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline1WithReplies.IshRef, $strMetadataReply)
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline1WithReplies.IshRef, $strMetadataReply)
-	$ishAnnotationIAGpipeline2WithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGpipeline2WithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline2WithReplies.IshRef, $strMetadataReply)
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline2WithReplies.IshRef, $strMetadataReply)
-	
-	# annotations for mixed test (with and without replies)
-	$ishAnnotationPipelineMixed = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$ishAnnotationPipelineMixedWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
-	$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGpipeline2WithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPipelineMixedWithReplies.IshRef, $strMetadataReply)
-	$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPipelineMixedWithReplies.IshRef, $strMetadataReply)
-	
+Describe "Remove-IshAnnotation" -Tags "Create" {
+	BeforeAll {
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
+		$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+
+		Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$global:ishAnnotationCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishAnnotationCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		
+		#add topic
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectTopic = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent `
+						| Get-IshDocumentObj -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng)
+		#add map
+		$ditaMap = $ditaMapWithTopicrefFileContent.Replace("<GUID-PLACEHOLDER>", $ishObjectTopic.IshRef)
+		$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectMap = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -Version '1' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMap
+		
+		#add publication
+		$ishPubMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap.IshRef |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+		$ishObjectPub = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata
+		
+		#add annotations
+		$revisionId = $ishObjectTopic.ed
+		$annotationAddress = "[{""revisionId"":""$revisionId"",""startContainerQuery"":""/*[1]/node()[1]/node()[1]"",""startOffset"":0,""endContainerQuery"":""/*[1]/node()[1]/node()[1]"",""endOffset"":4,""type"":""TEXT_RANGE_SELECTOR""}]"
+		$annotationText = "by ISHRemote Pester on $timestamp"
+		$annotationCategory = (Get-IshLovValue -LovId DANNOTATIONCATEGORY -LovValueId VANNOTATIONCATEGORYCOMMENT).Label
+		$annotationType = (Get-IshLovValue -LovId DANNOTATIONTYPE -LovValueId VANNOTATIONTYPEGENERAL).Label
+		$annotationStatus = (Get-IshLovValue -LovId DANNOTATIONSTATUS -LovValueId VANNOTATIONSTATUSUNSHARED).Label
+		
+		# Add annotations - ParametersGroup
+		$ishAnnotationPG1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationPGWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationPGWithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPGWithReplies.IshRef, $strMetadataReply)
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPGWithReplies.IshRef, $strMetadataReply)
+		
+		# Add annotations - IshAnnotationGroup
+		$ishAnnotationIAG1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationIAGWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGWithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGWithReplies.IshRef, $strMetadataReply)
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGWithReplies.IshRef, $strMetadataReply)
+		
+		# annotations for mixed test (with and without replies)
+		$ishAnnotationIAGMixed1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationIAGMixed2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationIAGMixedWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGWithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$ishsession.Annotation25.CreateReply($ishAnnotationIAGMixedWithReplies.IshRef, $strMetadataReply)
+		$ishsession.Annotation25.CreateReply($ishAnnotationIAGMixedWithReplies.IshRef, $strMetadataReply)
+		
+		# Add annotations - IshAnnotationGroup (pipeline)
+		$ishAnnotationIAGpipeline2 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationIAGpipeline1 = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationIAGpipeline1WithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGpipeline1WithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline1WithReplies.IshRef, $strMetadataReply)
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline1WithReplies.IshRef, $strMetadataReply)
+		$ishAnnotationIAGpipeline2WithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGpipeline2WithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline2WithReplies.IshRef, $strMetadataReply)
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationIAGpipeline2WithReplies.IshRef, $strMetadataReply)
+		
+		# annotations for mixed test (with and without replies)
+		$ishAnnotationPipelineMixed = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$ishAnnotationPipelineMixedWithReplies = Add-IshAnnotation -IshSession $ishsession -PubLogicalId $ishObjectPub.IshRef -PubVersion $ishObjectPub.version_version_value -PubLng $ishObjectPub.fishpubsourcelanguages_version_value -LogicalId $ishObjectTopic.IshRef -Version $ishObjectTopic.version_version_value -Lng $ishObjectTopic.doclanguage -Type $annotationType -Text $annotationText -Status $annotationStatus -Category $annotationCategory -Address $annotationAddress
+		$strMetadataReply = "<ishfields><ishfield name='FISHANNOTATIONTEXT' level='reply'>reply to an annotation $($ishAnnotationIAGpipeline2WithReplies.IshRef)</ishfield></ishfields>"  # Deliberate xml to pass straight as string on the proxy function
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPipelineMixedWithReplies.IshRef, $strMetadataReply)
+		$ishAnnotationReply = $ishsession.Annotation25.CreateReply($ishAnnotationPipelineMixedWithReplies.IshRef, $strMetadataReply)
+	}
 
 	Context "Remove-IshAnnotation ParametersGroup" {
 		It "Parameter AnnotationId is empty" {
-			{Remove-IshAnnotation -IshSession $ishsession -AnnotationId ""} | Should Throw
+			{Remove-IshAnnotation -IshSession $ishsession -AnnotationId ""} | Should -Throw
 		}
 		It "Parameter AnnotationId non-existing Id" {
-			{Remove-IshAnnotation -IshSession $ishsession -AnnotationId "GUID-NON-EXISTING"} | Should Throw
+			{Remove-IshAnnotation -IshSession $ishsession -AnnotationId "GUID-NON-EXISTING"} | Should -Throw
 		}
 		It "Annotation with replies" {
 			$ishAnnotation = Remove-IshAnnotation -IshSession $ishsession -AnnotationId $ishAnnotationPGWithReplies.IshRef
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId $ishAnnotationPGWithReplies.IshRef
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
 		It "Annotation without replies" {
 			$ishAnnotation = Remove-IshAnnotation -IshSession $ishsession -AnnotationId $ishAnnotationPG1.IshRef
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId $ishAnnotationPG1.IshRef
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
     }
 
 	Context "Remove-IshAnnotation IshAnnotationGroup" {
 		It "Annotation with replies" {
 			$ishAnnotation = Remove-IshAnnotation -IshSession $ishsession -IshAnnotation $ishAnnotationIAGWithReplies
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId $ishAnnotationIAGWithReplies.IshRef
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
 		It "Annotation without replies" {
 			$ishAnnotation = Remove-IshAnnotation -IshSession $ishsession -IshAnnotation $ishAnnotationIAG1
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId $ishAnnotationIAG1.IshRef
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
 		It "Annotations mixed(with and without replies), passing as array" {
 			$ishAnnotation = Remove-IshAnnotation -IshSession $ishsession -IshAnnotation @($ishAnnotationIAGMixed1, $ishAnnotationIAGMixedWithReplies, $ishAnnotationIAGMixed2)
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId @($ishAnnotationIAGMixed1.IshRef, $ishAnnotationIAGMixedWithReplies.IshRef, $ishAnnotationIAGMixed2.IshRef)
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
     }
 	
     Context "Remove-IshAnnotation IshAnnotationGroup pipeline" {
 		It "Passing empty collection via pipeline"{
             $ishObjects = Get-Ishfolder -IshSession $ishsession -FolderId ($global:ishAnnotationCmdlet.IshFolderRef) | Get-IshFolderContent -IshSession $ishsession
-            $ishObjects.Count | Should Be 0
+            $ishObjects.Count | Should -Be 0
             {Get-Ishfolder -IshSession $ishsession -FolderId ($global:ishAnnotationCmdlet.IshFolderRef) |
             Get-IshFolderContent -IshSession $ishsession |
-            Remove-IshAnnotation -IshSession $ishsession} | Should Not Throw
+            Remove-IshAnnotation -IshSession $ishsession} | Should -Not -Throw
 		}
 		It "Annotations with replies, passing one by one" {
 			$ishAnnotation = @($ishAnnotationIAGpipeline1WithReplies, $ishAnnotationIAGpipeline2WithReplies) | Remove-IshAnnotation -IshSession $ishsession
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId @($ishAnnotationIAGpipeline1WithReplies.IshRef, $ishAnnotationIAGpipeline2WithReplies.IshRef)
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
 		It "Annotations without replies, passing one by one" {
 			$ishAnnotation = @($ishAnnotationIAGpipeline2, $ishAnnotationIAGpipeline1) | Remove-IshAnnotation -IshSession $ishsession
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId @($ishAnnotationIAGpipeline2.IshRef,  $ishAnnotationIAGpipeline1.IshRef)
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
 		It "Annotations mixed(with and without replies), passing whole array" {
 			$ishAnnotation = @($ishAnnotationPipelineMixed, $ishAnnotationPipelineMixedWithReplies) | Remove-IshAnnotation -IshSession $ishsession
-			$ishAnnotation -eq $null | Should Be $true
+			$ishAnnotation -eq $null | Should -Be $true
             $ishAnnotation = Get-IshAnnotation -IshSession $ishsession -AnnotationId @($ishAnnotationPipelineMixed.IshRef, $ishAnnotationPipelineMixedWithReplies.IshRef)
-            $ishAnnotation.Count | Should Be 0
+            $ishAnnotation.Count | Should -Be 0
 		}
     }
 }
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
     $publicationOutputs = Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse |
                           Where-Object -Property IshFolderType -EQ -Value "ISHPublication" | 

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Application/GetIshVersion.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Application/GetIshVersion.Tests.ps1
@@ -1,56 +1,61 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshVersion"
-try {
-	Write-Host "Initializing Test Data and Variables"
+BeforeAll {
+	$cmdletName = "Get-IshVersion"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshVersion" -Tags "Read" {
-	Context “Get-IshVersion Parameters" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe "Get-IshVersion" -Tags "Read" {
+	Context "Get-IshVersion Parameters" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshVersion -IshSession "INVALIDISHSESSION" } | Should Throw
+			{ Get-IshVersion -IshSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
 
 	Context "Get-IshVersion returns IshVersion object" {
-		$ishVersion = Get-IshVersion -IshSession $ishSession
+		BeforeAll {
+			$ishVersion = Get-IshVersion -IshSession $ishSession
+		}
 		It "GetType()" {
-			$ishVersion.GetType().Name | Should BeExactly "IshVersion"
+			$ishVersion.GetType().Name | Should -BeExactly "IshVersion"
 		}
 		It "IshVersion.MajorVersion" {
-			$ishVersion.MajorVersion -ge 0 | Should Be $true
+			$ishVersion.MajorVersion -ge 0 | Should -Be $true
 		}
 		It "IshVersion.MinorVersion" {
-			$ishVersion.MinorVersion -ge 0 | Should Be $true
+			$ishVersion.MinorVersion -ge 0 | Should -Be $true
 		}
 		It "IshVersion.BuildVersion" {
-			$ishVersion.BuildVersion -ge 0 | Should Be $true
+			$ishVersion.BuildVersion -ge 0 | Should -Be $true
 		}
 		It "IshSession.RevisionVersion" {
-			$ishVersion.RevisionVersion -ge 0 | Should Be $true
+			$ishVersion.RevisionVersion -ge 0 | Should -Be $true
 		}
 	}
 
 	Context "Get-IshVersion without IshSession returns IshVersion object" {
-		$ishVersion = Get-IshVersion
+		BeforeAll {
+			$ishVersion = Get-IshVersion
+		}
 		It "GetType()" {
-			$ishVersion.GetType().Name | Should BeExactly "IshVersion"
+			$ishVersion.GetType().Name | Should -BeExactly "IshVersion"
 		}
 		It "IshVersion.MajorVersion" {
-			$ishVersion.MajorVersion -ge 0 | Should Be $true
+			$ishVersion.MajorVersion -ge 0 | Should -Be $true
 		}
 		It "IshVersion.MinorVersion" {
-			$ishVersion.MinorVersion -ge 0 | Should Be $true
+			$ishVersion.MinorVersion -ge 0 | Should -Be $true
 		}
 		It "IshVersion.BuildVersion" {
-			$ishVersion.BuildVersion -ge 0 | Should Be $true
+			$ishVersion.BuildVersion -ge 0 | Should -Be $true
 		}
 		It "IshSession.RevisionVersion" {
-			$ishVersion.RevisionVersion -ge 0 | Should Be $true
+			$ishVersion.RevisionVersion -ge 0 | Should -Be $true
 		}
 	}
 }
-
 	
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/BackgroundTask/AddIshBackgroundTask.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/BackgroundTask/AddIshBackgroundTask.Tests.ps1
@@ -1,239 +1,260 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshBackgroundTask"
+BeforeAll {
+	$cmdletName = "Add-IshBackgroundTask"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
 
-#
-# Script-file scope auxiliary function
-# Gets BackgroundTasks InputData to parse out the language cardids passed to the BackgroundTask event
-#
-function script:GetLngRefsByInputDataId([long]$inputDataId)
-{
-	[xml]$xmlBTDataObject = $ishSession.BackgroundTask25.RetrieveDataObjectByIshDataRefs($inputDataId)
-	[byte[]]$data = [Convert]::FromBase64String($xmlBTDataObject.ishbackgroundtaskdataobjects.ishbackgroundtaskdataobject."#cdata-section")
-	
-	#find where xml really starts
-	$position = 0
-	foreach($byte in $data)
+	#
+	# Script-file scope auxiliary function
+	# Gets BackgroundTasks InputData to parse out the language cardids passed to the BackgroundTask event
+	#
+	function script:GetLngRefsByInputDataId([long]$inputDataId)
 	{
-		if($byte -eq "60"){
-			break;
+		[xml]$xmlBTDataObject = $ishSession.BackgroundTask25.RetrieveDataObjectByIshDataRefs($inputDataId)
+		[byte[]]$data = [Convert]::FromBase64String($xmlBTDataObject.ishbackgroundtaskdataobjects.ishbackgroundtaskdataobject."#cdata-section")
+		
+		#find where xml really starts
+		$position = 0
+		foreach($byte in $data)
+		{
+			if($byte -eq "60"){
+				break;
+			}
+			$position ++
 		}
-		$position ++
+		
+		#convert to xml
+		[xml]$xmlContent = [System.Text.Encoding]::Unicode.GetString($data, $position, $data.Length - $position)
+		$retrievedLngRefsArray = @()
+		foreach($ishObject in $xmlContent.ishobjects.ishobject) 
+		{
+			$retrievedLngRefsArray += $ishObject.ishlngRef
+		}
+		
+		return $retrievedLngRefsArray
 	}
-	
-	#convert to xml
-	[xml]$xmlContent = [System.Text.Encoding]::Unicode.GetString($data, $position, $data.Length - $position)
-	$retrievedLngRefsArray = @()
-	foreach($ishObject in $xmlContent.ishobjects.ishobject) 
+
+
+	#
+	# Script-file scope auxiliary function
+	# For every incoming IshBackgroundTask, retrieve InputData (that holds language cardids of the BackgroundTask event) and return as an array
+	#
+	function script:GetLngRefsByBackgroundTasksArray($arrBackgroundTasks)
 	{
-		$retrievedLngRefsArray += $ishObject.ishlngRef
+		if ($arrBackgroundTasks.Count -eq 0)
+		{
+			return $null
+		}
+		
+		$retrievedLngRefs = @()
+		foreach($ishBackgroundTask in $arrBackgroundTasks)
+		{
+			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID 
+			$ishBackgroundTask = $ishBackgroundTask | Get-IshBackgroundTask -RequestedMetadata $requestedMetadata
+			$retrievedLngRefs += GetLngRefsByInputDataId -inputDataId $ishBackgroundTask.inputdataid
+		}
+		return $retrievedLngRefs
 	}
-	
-	return $retrievedLngRefsArray
 }
 
+Describe "Add-IshBackgroundTask" -Tags "Create" {
+	BeforeAll {
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
+		$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
+		
+		Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$global:ishBackgroundTaskCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishBackgroundTaskCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
-#
-# Script-file scope auxiliary function
-# For every incoming IshBackgroundTask, retrieve InputData (that holds language cardids of the BackgroundTask event) and return as an array
-#
-function script:GetLngRefsByBackgroundTasksArray($arrBackgroundTasks)
-{
-	if ($arrBackgroundTasks.Count -eq 0)
-	{
-		return $null
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+							Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+
+		$ishObjectTopic1_1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT1" -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic1_2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT1" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic1_3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT1" -Version '3' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+
+		$ishObjectTopic2_1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT2" -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic2_2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT2" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic2_3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT2" -Version '3' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+
+		$ishObjectTopic3_1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic3_2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic3_3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '3' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		$ishObjectTopic3_4 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '4' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+
+		$ishObjects = $ishFolderTopic | Get-IshFolderContent -IshSession $ishSession -VersionFilter ""
+		$createdLngRefs = $ishObjects | select -ExpandProperty LngRef
 	}
-	
-	$retrievedLngRefs = @()
-	foreach($ishBackgroundTask in $arrBackgroundTasks)
-	{
-		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID 
-		$ishBackgroundTask = $ishBackgroundTask | Get-IshBackgroundTask -RequestedMetadata $requestedMetadata
-		$retrievedLngRefs += GetLngRefsByInputDataId -inputDataId $ishBackgroundTask.inputdataid
-	}
-	return $retrievedLngRefs
-}
-
-try {
-
-Describe “Add-IshBackgroundTask" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	$ownedByTestRootOriginal = $ishFolderTestRootOriginal.fusergroup_none_element
-	$readAccessTestRootOriginal = $ishFolderTestRootOriginal.readaccess_none_element
-	
-    Write-Debug("folderIdTestRootOriginal[" +  $ishFolderTestRootOriginal.IshFolderRef + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$global:ishBackgroundTaskCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishBackgroundTaskCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-
-	$ishObjectTopic1_1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT1" -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic1_2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT1" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic1_3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT1" -Version '3' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-
-	$ishObjectTopic2_1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT2" -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic2_2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT2" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic2_3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT2" -Version '3' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-
-	$ishObjectTopic3_1 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic3_2 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic3_3 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '3' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-	$ishObjectTopic3_4 = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "ISHREMOTE-LOGICALID-TOPIC-FORADDBT3" -Version '4' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-
-	$ishObjects = $ishFolderTopic | Get-IshFolderContent -IshSession $ishSession -VersionFilter ""
-	$createdLngRefs = $ishObjects | select -ExpandProperty LngRef
-	
-
 	Context "Add-IshBackgroundTask IshObjectsGroup Parameter IshObject with implicit IshSession since 14SP4/14.0.4" {
 		if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 			It "Parameter IshObject invalid" {
-				{ Add-IshBackgroundTask -EventType $ishEventTypeToPurge -IshObject "INVALIDISHOBJECT" } | Should Throw
+				{ Add-IshBackgroundTask -EventType $ishEventTypeToPurge -IshObject "INVALIDISHOBJECT" } | Should -Throw
 			}
 			It "Parameter EventType null" {
-				{ Add-IshBackgroundTask -EventType $null -IshObject  $ishObjects } | Should Throw
+				{ Add-IshBackgroundTask -EventType $null -IshObject  $ishObjects } | Should -Throw
 			}
 			It "Pipeline IshObject Single" {
 				$ishBackgroundTaskIshObjectsParameter = Add-IshBackgroundTask -EventType $ishEventTypeToPurge -IshObject $ishObjectTopic1_1
-				$ishObjectTopic1_1.Count | Should BeExactly 1
-				$ishBackgroundTaskIshObjectsParameter.Count | Should BeExactly 1
-				$ishBackgroundTaskIshObjectsParameter.GetType() | Should BeExactly Trisoft.ISHRemote.Objects.Public.IshBackgroundTask
-				$ishBackgroundTaskIshObjectsParameter.EventType | Should BeExactly $ishEventTypeToPurge
-				$ishBackgroundTaskIshObjectsParameter.userid | Should BeExactly $ishSession.UserName
+				$ishObjectTopic1_1.Count | Should -BeExactly 1
+				$ishBackgroundTaskIshObjectsParameter.Count | Should -BeExactly 1
+				$ishBackgroundTaskIshObjectsParameter.GetType() | Should -BeExactly Trisoft.ISHRemote.Objects.Public.IshBackgroundTask
+				$ishBackgroundTaskIshObjectsParameter.EventType | Should -BeExactly $ishEventTypeToPurge
+				$ishBackgroundTaskIshObjectsParameter.userid | Should -BeExactly $ishSession.UserName
 			}
 			It "Pipeline IshObject Multiple" {
 				$ishBackgroundTaskIshObjectsParameter = Add-IshBackgroundTask -EventType $ishEventTypeToPurge -IshObject $ishObjects
-				$ishBackgroundTaskIshObjectsParameter.Count | Should BeExactly 1
-				$ishBackgroundTaskIshObjectsParameter.GetType() | Should BeExactly Trisoft.ISHRemote.Objects.Public.IshBackgroundTask
-				$ishBackgroundTaskIshObjectsParameter.EventType | Should BeExactly $ishEventTypeToPurge
-				$ishBackgroundTaskIshObjectsParameter.userid | Should BeExactly $ishSession.UserName
+				$ishBackgroundTaskIshObjectsParameter.Count | Should -BeExactly 1
+				$ishBackgroundTaskIshObjectsParameter.GetType() | Should -BeExactly Trisoft.ISHRemote.Objects.Public.IshBackgroundTask
+				$ishBackgroundTaskIshObjectsParameter.EventType | Should -BeExactly $ishEventTypeToPurge
+				$ishBackgroundTaskIshObjectsParameter.userid | Should -BeExactly $ishSession.UserName
 			}
 		}
 	}
 
 	Context "Add-IshBackgroundTask IshObjectsGroup Pipeline IshObject since 14SP4/14.0.4" {
-		if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
-			$ishBackgroundTaskIshObjectsPipeline = $ishObjects | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
-			It "Add-IshBackgroundTask returns IshBackgroundTask object" {
-				$ishObjects.Count | Should BeExactly 10
-				$ishBackgroundTaskIshObjectsPipeline.Count | Should BeExactly 1
-				$ishBackgroundTaskIshObjectsPipeline.GetType().Name | Should BeExactly "IshBackgroundTask"
-				$ishBackgroundTaskIshObjectsPipeline.EventType | Should BeExactly $ishEventTypeToPurge
-				$ishBackgroundTaskIshObjectsPipeline.userid | Should BeExactly $ishSession.UserName
+		BeforeAll {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
+				$ishBackgroundTaskIshObjectsPipeline = $ishObjects | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
 			}
-			It "Add-IshBackgroundTask returns IshBackgroundTask that launched with correct card ids" {
+			$savedMetadataBatchSize = $ishSession.MetadataBatchSize
+		}
+		It "Add-IshBackgroundTask returns IshBackgroundTask object" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
+				$ishObjects.Count | Should -BeExactly 10
+				$ishBackgroundTaskIshObjectsPipeline.Count | Should -BeExactly 1
+				$ishBackgroundTaskIshObjectsPipeline.GetType().Name | Should -BeExactly "IshBackgroundTask"
+				$ishBackgroundTaskIshObjectsPipeline.EventType | Should -BeExactly $ishEventTypeToPurge
+				$ishBackgroundTaskIshObjectsPipeline.userid | Should -BeExactly $ishSession.UserName
+			}
+		}
+		It "Add-IshBackgroundTask returns IshBackgroundTask that launched with correct card ids" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 				$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID 
 				$ishBackgroundTaskIshObjectsPipeline = $ishBackgroundTaskIshObjectsPipeline | Get-IshBackgroundTask -RequestedMetadata $requestedMetadata
 				$retrievedLngRefs = GetLngRefsByInputDataId -inputDataId $ishBackgroundTaskIshObjectsPipeline.inputdataid
-				$retrievedLngRefs.Count | Should BeExactly $createdLngRefs.Count
+				$retrievedLngRefs.Count | Should -BeExactly $createdLngRefs.Count
 				foreach($lngRef in $retrievedLngRefs)
 				{
-					$createdLngRefs -contains $lngRef | Should BeExactly $true
+					$createdLngRefs -contains $lngRef | Should -BeExactly $true
 				}
 			}
-			It "Pipeline IshObject Single" {
+		}
+		It "Pipeline IshObject Single" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 				$ishBackgroundTaskIshObjectsPipeline = $ishObjectTopic1_1 | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
-				$ishObjectTopic1_1.Count | Should BeExactly 1
-				$ishBackgroundTaskIshObjectsPipeline.Count | Should BeExactly 1
-				$ishBackgroundTaskIshObjectsPipeline.GetType().Name | Should BeExactly "IshBackgroundTask"
-				$ishBackgroundTaskIshObjectsPipeline.EventType | Should BeExactly $ishEventTypeToPurge
-				$ishBackgroundTaskIshObjectsPipeline.userid | Should BeExactly $ishSession.UserName
+				$ishObjectTopic1_1.Count | Should -BeExactly 1
+				$ishBackgroundTaskIshObjectsPipeline.Count | Should -BeExactly 1
+				$ishBackgroundTaskIshObjectsPipeline.GetType().Name | Should -BeExactly "IshBackgroundTask"
+				$ishBackgroundTaskIshObjectsPipeline.EventType | Should -BeExactly $ishEventTypeToPurge
+				$ishBackgroundTaskIshObjectsPipeline.userid | Should -BeExactly $ishSession.UserName
 			}
-			$savedMetadataBatchSize = $ishSession.MetadataBatchSize
-			It "Pipeline IshObject MetadataBatchSize[2] with LogicalId grouping" {
+		}
+		It "Pipeline IshObject MetadataBatchSize[2] with LogicalId grouping" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 				$ishSession.MetadataBatchSize = 2
 				$ishBackgroundTasks = $ishObjects | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
-				$ishBackgroundTasks.Count | Should BeExactly 3
+				$ishBackgroundTasks.Count | Should -BeExactly 3
 				$retrievedLngRefs = GetLngRefsByBackgroundTasksArray -arrBackgroundTasks $ishBackgroundTasks
-				$retrievedLngRefs.Count | Should BeExactly $createdLngRefs.Count
+				$retrievedLngRefs.Count | Should -BeExactly $createdLngRefs.Count
 				foreach($lngRef in $retrievedLngRefs)
 				{
-					$createdLngRefs -contains $lngRef | Should BeExactly $true
+					$createdLngRefs -contains $lngRef | Should -BeExactly $true
 				}
 			}
-			It "Pipeline IshObject MetadataBatchSize[4] with LogicalId grouping" {
+		}
+		It "Pipeline IshObject MetadataBatchSize[4] with LogicalId grouping" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 				$ishSession.MetadataBatchSize = 4
 				$ishBackgroundTasks = $ishObjects | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
-				$ishBackgroundTasks.Count | Should BeExactly 3
+				$ishBackgroundTasks.Count | Should -BeExactly 3
 				$retrievedLngRefs = GetLngRefsByBackgroundTasksArray -arrBackgroundTasks $ishBackgroundTasks
-				$retrievedLngRefs.Count | Should BeExactly $createdLngRefs.Count
+				$retrievedLngRefs.Count | Should -BeExactly $createdLngRefs.Count
 				foreach($lngRef in $retrievedLngRefs)
 				{
-					$createdLngRefs -contains $lngRef | Should BeExactly $true
+					$createdLngRefs -contains $lngRef | Should -BeExactly $true
 				}
 			}
-			It "Pipeline IshObject MetadataBatchSize[6] with LogicalId grouping" {
+		}
+		It "Pipeline IshObject MetadataBatchSize[6] with LogicalId grouping" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 				$ishSession.MetadataBatchSize = 6
 				$ishBackgroundTasks = $ishObjects | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
-				$ishBackgroundTasks.Count | Should BeExactly 2
+				$ishBackgroundTasks.Count | Should -BeExactly 2
 				$retrievedLngRefs = GetLngRefsByBackgroundTasksArray -arrBackgroundTasks $ishBackgroundTasks
-				$retrievedLngRefs.Count | Should BeExactly $createdLngRefs.Count
+				$retrievedLngRefs.Count | Should -BeExactly $createdLngRefs.Count
 				foreach($lngRef in $retrievedLngRefs)
 				{
-					$createdLngRefs -contains $lngRef | Should BeExactly $true
+					$createdLngRefs -contains $lngRef | Should -BeExactly $true
 				}
 			}
-			It "Pipeline IshObject MetadataBatchSize[10] with LogicalId grouping" {
+		}
+		It "Pipeline IshObject MetadataBatchSize[10] with LogicalId grouping" {
+			if (([Version]$ishSession.ServerVersion).Major -ge 15 -or (([Version]$ishSession.ServerVersion).Major -ge 14 -and ([Version]$ishSession.ServerVersion).Revision -ge 4)) { 
 				$ishSession.MetadataBatchSize = 10
 				$ishBackgroundTasks = $ishObjects | Add-IshBackgroundTask -IshSession $ishSession -EventType $ishEventTypeToPurge
-				$ishBackgroundTasks.Count | Should BeExactly 1
+				$ishBackgroundTasks.Count | Should -BeExactly 1
 				$retrievedLngRefs = GetLngRefsByBackgroundTasksArray -arrBackgroundTasks $ishBackgroundTasks
-				$retrievedLngRefs.Count | Should BeExactly $createdLngRefs.Count
+				$retrievedLngRefs.Count | Should -BeExactly $createdLngRefs.Count
 				foreach($lngRef in $retrievedLngRefs)
 				{
-					$createdLngRefs -contains $lngRef | Should BeExactly $true
+					$createdLngRefs -contains $lngRef | Should -BeExactly $true
 				}
 			}
+		}
+		AfterAll {
 			$ishSession.MetadataBatchSize = $savedMetadataBatchSize
 		}
 	}
 	
 	Context "Add-IshBackgroundTask ParameterGroup" {
-		# If you get the below error, it means you configured default purge operation $ishEventTypetoPurge (defaults to PUSHTRANSLATIONS in ISHRemote.PesterSetup.ps1) away
-		# FaultException`1: [-105001] The parameter eventType with value "PUSHTRANSLATIONS" is invalid. Make sure a handler with the eventType is configured in the Background Task Configuration XML [105001;InvalidParameter]
-		$rawData = "<data><dataExample>Text</dataExample></data>"
-		$eventDescription = "Created by Powershell and ISHRemote"
-		$ishBackgroundTaskParameters = Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription $eventDescription -RawInputData $rawData
+		BeforeAll {
+			# If you get the below error, it means you configured default purge operation $ishEventTypetoPurge (defaults to PUSHTRANSLATIONS in ISHRemote.PesterSetup.ps1) away
+			# FaultException`1: [-105001] The parameter eventType with value "PUSHTRANSLATIONS" is invalid. Make sure a handler with the eventType is configured in the Background Task Configuration XML [105001;InvalidParameter]
+			$rawData = "<data><dataExample>Text</dataExample></data>"
+			$eventDescription = "Created by Powershell and ISHRemote"
+			$ishBackgroundTaskParameters = Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription $eventDescription -RawInputData $rawData
+		}
 		It "Add-IshBackgroundTask returns IshBackgroundTask object" {
-			$ishBackgroundTaskParameters.Count | Should BeExactly 1
-			$ishBackgroundTaskParameters.GetType().Name | Should BeExactly "IshBackgroundTask"
-			$ishBackgroundTaskParameters.EventType | Should BeExactly $ishEventTypeToPurge
-			$ishBackgroundTaskParameters.userid | Should BeExactly $ishSession.UserName
+			$ishBackgroundTaskParameters.Count | Should -BeExactly 1
+			$ishBackgroundTaskParameters.GetType().Name | Should -BeExactly "IshBackgroundTask"
+			$ishBackgroundTaskParameters.EventType | Should -BeExactly $ishEventTypeToPurge
+			$ishBackgroundTaskParameters.userid | Should -BeExactly $ishSession.UserName
 		}
 		It "Parameter EventDescription null" {
-			{ Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription $null -RawInputData $rawData } | Should Throw
+			{ Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription $null -RawInputData $rawData } | Should -Throw
 		}
 		It "Parameter EventType null" {
-			{ Add-IshBackgroundTask -EventType $null -EventDescription $eventDescription -RawInputData $rawData } | Should Throw
+			{ Add-IshBackgroundTask -EventType $null -EventDescription $eventDescription -RawInputData $rawData } | Should -Throw
 		}
 		It "Parameter RawInputData null" {
-			{ Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription $eventDescription -RawInputData $null } | Should Throw
+			{ Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription $eventDescription -RawInputData $null } | Should -Throw
 		}
 		It "Parameter StartAfter Tommorrow" {
 			$dateTomorrow = (Get-Date).AddDays(1)
 			$ishBackgroundTaskStartsAfter = Add-IshBackgroundTask -EventType $ishEventTypeToPurge -EventDescription ($eventDescription + " StartAfter") -RawInputData $rawData -StartAfter $dateTomorrow
-			$ishBackgroundTaskStartsAfter.Count | Should BeExactly 1
-			($ishBackgroundTaskStartsAfter.executeafterdate -eq $ishBackgroundTaskStartsAfter.creationdate) | Should Be $false
-			$ishBackgroundTaskStartsAfter.GetType().Name | Should BeExactly "IshBackgroundTask"
-			$ishBackgroundTaskStartsAfter.EventType | Should BeExactly $ishEventTypeToPurge
-			$ishBackgroundTaskStartsAfter.userid | Should BeExactly $ishSession.UserName
+			$ishBackgroundTaskStartsAfter.Count | Should -BeExactly 1
+			($ishBackgroundTaskStartsAfter.executeafterdate -eq $ishBackgroundTaskStartsAfter.creationdate) | Should -Be $false
+			$ishBackgroundTaskStartsAfter.GetType().Name | Should -BeExactly "IshBackgroundTask"
+			$ishBackgroundTaskStartsAfter.EventType | Should -BeExactly $ishEventTypeToPurge
+			$ishBackgroundTaskStartsAfter.userid | Should -BeExactly $ishSession.UserName
 			# Verify returned submitted IshBackgroundTask.StartsAfter date matches provided tomorrow StartsAfter
 			$retrievedExecuteAfter = New-Object DateTime
 			$conversionResult = [DateTime]::TryParseExact($ishBackgroundTaskStartsAfter.executeafterdate, "yyyy-MM-ddTHH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::None, [ref]$retrievedExecuteAfter)
-			$conversionResult | Should BeExactly $true
-			$retrievedExecuteAfter.ToString("dd/MM/yyyy") | Should BeExactly $dateTomorrow.ToString("dd/MM/yyyy")	
+			$conversionResult | Should -BeExactly $true
+			$retrievedExecuteAfter.ToString("dd/MM/yyyy") | Should -BeExactly $dateTomorrow.ToString("dd/MM/yyyy")	
 		}
 	}
 }
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession -VersionFilter "" | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/BackgroundTask/GetIshBackgroundTask.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/BackgroundTask/GetIshBackgroundTask.Tests.ps1
@@ -1,162 +1,166 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshBackgroundTask"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshBackgroundTask"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshBackgroundTask" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObject = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
-				 Set-IshDocumentObj -IshSession $ishSession -Metadata (Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased)
+Describe "Get-IshBackgroundTask" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-
-    $allTaskMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CREATIONDATE  | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CURRENTATTEMPT |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EVENTTYPE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EXECUTEAFTERDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name HASHID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDBY |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDON |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name MODIFICATIONDATE | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name OUTPUTDATAID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name PROGRESSID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TASKID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TRACKINGID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name USERID -ValueType Element
-    $allHistMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ENDDATE | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERROR |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERRORNUMBER |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name EXITCODE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HISTORYID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HOSTNAME |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name OUTPUT |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name STARTDATE
-    $allMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CREATIONDATE  | 
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CURRENTATTEMPT |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EVENTTYPE |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EXECUTEAFTERDATE |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name HASHID | 
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDBY |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDON |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name MODIFICATIONDATE | 
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name OUTPUTDATAID |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name PROGRESSID |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Value |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Element |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TASKID |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TRACKINGID |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name USERID -ValueType Element |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ENDDATE | 
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERROR |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERRORNUMBER |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name EXITCODE |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HISTORYID | 
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HOSTNAME |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name OUTPUT |
-                   Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name STARTDATE
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+							Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObject = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
+					Set-IshDocumentObj -IshSession $ishSession -Metadata (Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased)
 
 
-	Context "Get-IshBackgroundTask" {
-		$metadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TASKID | 
-		            Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name HISTORYID |
+		$allTaskMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CREATIONDATE  | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CURRENTATTEMPT |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EVENTTYPE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EXECUTEAFTERDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name HASHID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDBY |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDON |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name MODIFICATIONDATE | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name OUTPUTDATAID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name PROGRESSID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TASKID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TRACKINGID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name USERID -ValueType Element
+		$allHistMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ENDDATE | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERROR |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERRORNUMBER |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name EXITCODE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HISTORYID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HOSTNAME |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name OUTPUT |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name STARTDATE
+		$allMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CREATIONDATE  | 
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name CURRENTATTEMPT |
 					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EVENTTYPE |
-					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name PROGRESSID 
-		$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -UserFilter All -RequestedMetadata $metadata)[0]
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EXECUTEAFTERDATE |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name HASHID | 
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name INPUTDATAID |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDBY |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name LEASEDON |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name MODIFICATIONDATE | 
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name OUTPUTDATAID |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name PROGRESSID |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Value |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Element |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TASKID |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TRACKINGID |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name USERID -ValueType Element |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ENDDATE | 
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERROR |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name ERRORNUMBER |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name EXITCODE |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HISTORYID | 
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name HOSTNAME |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name OUTPUT |
+					Set-IshRequestedMetadataField -IshSession $ishSession -Level History -Name STARTDATE
+	}
+	Context "Get-IshBackgroundTask" {
+		BeforeAll {
+			$metadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name TASKID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name HISTORYID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name EVENTTYPE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Task -Name PROGRESSID 
+			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -UserFilter All -RequestedMetadata $metadata)[0]
+		}
 		It "GetType().Name" {
-			$ishBackgroundTask.GetType().Name | Should BeExactly "IshBackgroundTask"
+			$ishBackgroundTask.GetType().Name | Should -BeExactly "IshBackgroundTask"
 		}
 		It "ishObject.IshField" {
-			$ishBackgroundTask.IshField | Should Not BeNullOrEmpty
+			$ishBackgroundTask.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.IshRef" {
-			$ishBackgroundTask.IshRef | Should Not BeNullOrEmpty
+			$ishBackgroundTask.IshRef | Should -Not -BeNullOrEmpty
 		}
 		# Double check following 2 ReferenceType enum usage 
 		It "ishBackgroundTask.TaskRef" {
-			$ishBackgroundTask.TaskRef | Should Not BeNullOrEmpty
+			$ishBackgroundTask.TaskRef | Should -Not -BeNullOrEmpty
 		}
 		#It "ishBackgroundTask.HistoryRef" {
-		#	$ishBackgroundTask.HistoryRef | Should Not BeNullOrEmpty
+		#	$ishBackgroundTask.HistoryRef | Should -Not -BeNullOrEmpty
 		#}
 		It "ishBackgroundTask ConvertTo-Json" {
-			(ConvertTo-Json $ishBackgroundTask).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishBackgroundTask).Length -gt 2 | Should -Be $true
 		}
 		It "Parameter IshSession/ModifiedSince/UserFilter invalid" {
-			{ Get-IshBackgroundTask -IShSession "INVALIDISHSESSION" -ModifiedSince "INVALIDDATE" -UserFilter "INVALIDUSERFILTER" } | Should Throw
+			{ Get-IshBackgroundTask -IShSession "INVALIDISHSESSION" -ModifiedSince "INVALIDDATE" -UserFilter "INVALIDUSERFILTER" } | Should -Throw
 		}
 		It "Parameter RequestedMetadata/MetadataFile invalid" {
-			{ Get-IshBackgroundTask -IShSession $ishSession -RequestedMetadata "INVALIDMETADATA" -MetadataFilter "INVALIDFILTER"  } | Should Throw
+			{ Get-IshBackgroundTask -IShSession $ishSession -RequestedMetadata "INVALIDMETADATA" -MetadataFilter "INVALIDFILTER"  } | Should -Throw
 		}
 		It "Parameter IshSession/UserFilter/MetadataFilter are optional" {
 			$ishBackgroundTask = (Get-IshBackgroundTask -ModifiedSince ((Get-Date).AddSeconds(-10)) -RequestedMetadata $allTaskMetadata)[0]
-			($ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name USERID -ValueType Element).StartsWith('VUSER') | Should Be $true
-			($ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Element).StartsWith('VBACKGROUNDTASK') | Should Be $true
+			($ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name USERID -ValueType Element).StartsWith('VUSER') | Should -Be $true
+			($ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name STATUS -ValueType Element).StartsWith('VBACKGROUNDTASK') | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "Descriptive"
 			$ishBackgroundTask = (Get-IshBackgroundTask -IShSession $ishSession)[0]
-			(($ishBackgroundTask.IshField.Count -eq 1) -or ($ishBackgroundTask.IshField.Count -eq 2)) | Should Be $true  # Either BackgroundTask has run and you get taskid/historyid, or it didn't and you only get taskid
+			(($ishBackgroundTask.IshField.Count -eq 1) -or ($ishBackgroundTask.IshField.Count -eq 2)) | Should -Be $true  # Either BackgroundTask has run and you get taskid/historyid, or it didn't and you only get taskid
 			$ishSession.DefaultRequestedMetadata = "Basic"
 			$ishBackgroundTask = (Get-IshBackgroundTask -IShSession $ishSession)[0]
-			$ishBackgroundTask.status.Length -ge 1 | Should Be $true
-			$ishBackgroundTask.status_task_element.StartsWith('VBACKGROUNDTASKSTATUS') | Should Be $true 
-			(($ishBackgroundTask.IshField.Count -eq 13) -or ($ishBackgroundTask.IshField.Count -eq 19)) | Should Be $true
+			$ishBackgroundTask.status.Length -ge 1 | Should -Be $true
+			$ishBackgroundTask.status_task_element.StartsWith('VBACKGROUNDTASKSTATUS') | Should -Be $true 
+			(($ishBackgroundTask.IshField.Count -eq 13) -or ($ishBackgroundTask.IshField.Count -eq 19)) | Should -Be $true
 			$ishSession.DefaultRequestedMetadata = "All"
 			$ishBackgroundTask = (Get-IshBackgroundTask -IShSession $ishSession)[0]
-			(($ishBackgroundTask.IshField.Count -eq 18) -or ($ishBackgroundTask.IshField.Count -eq 26)) | Should Be $true
+			(($ishBackgroundTask.IshField.Count -eq 18) -or ($ishBackgroundTask.IshField.Count -eq 26)) | Should -Be $true
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
 		}
 		It "Parameter ModifiedSince is now" {
-			(Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(1)) -UserFilter All).Count | Should Be 0
+			(Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(1)) -UserFilter All).Count | Should -Be 0
 		}
 		It "Parameter RequestedMetadata only all of Task level" {
 			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddSeconds(-10)) -UserFilter All -RequestedMetadata $allTaskMetadata)[0]
-			$ishBackgroundTask.TaskRef -gt 0 | Should Be $true
-			$ishBackgroundTask.IshField.Count -ge 16 | Should Be $true
+			$ishBackgroundTask.TaskRef -gt 0 | Should -Be $true
+			$ishBackgroundTask.IshField.Count -ge 16 | Should -Be $true
 		}
 		It "Parameter RequestedMetadata only all of History level" {
 			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter All -RequestedMetadata $allHistMetadata)[0]
-			$ishBackgroundTask.TaskRef -gt 0 | Should Be $true
-			#$ishBackgroundTask.HistoryRef -gt 0 | Should Be $true
-			$ishBackgroundTask.IshField.Count -ge 1 | Should Be $true  # At least 1 entries returned if BackgroundTask service is not running, otherwise more
+			$ishBackgroundTask.TaskRef -gt 0 | Should -Be $true
+			#$ishBackgroundTask.HistoryRef -gt 0 | Should -Be $true
+			$ishBackgroundTask.IshField.Count -ge 1 | Should -Be $true  # At least 1 entries returned if BackgroundTask service is not running, otherwise more
 		}
 		It "Parameter RequestedMetadata PipelineObjectPreference=PSObjectNoteProperty" {
-			$ishSession.PipelineObjectPreference | Should Be "PSObjectNoteProperty"
+			$ishSession.PipelineObjectPreference | Should -Be "PSObjectNoteProperty"
 			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter All -RequestedMetadata $allMetadata)[0]
-			$ishBackgroundTask.GetType().Name | Should BeExactly "IshBackgroundTask"  # and not PSObject
-			[bool]($ishBackgroundTask.PSobject.Properties.name -match "status_task_element") | Should Be $true
-			[bool]($ishBackgroundTask.PSobject.Properties.name -match "userid_task_element") | Should Be $true
-			[bool]($ishBackgroundTask.PSobject.Properties.name -match "modificationdate") | Should Be $true
-			$ishBackgroundTask.modificationdate -like "*/*" | Should Be $false  # It should be sortable date format: yyyy-MM-ddTHH:mm:ss
+			$ishBackgroundTask.GetType().Name | Should -BeExactly "IshBackgroundTask"  # and not PSObject
+			[bool]($ishBackgroundTask.PSobject.Properties.name -match "status_task_element") | Should -Be $true
+			[bool]($ishBackgroundTask.PSobject.Properties.name -match "userid_task_element") | Should -Be $true
+			[bool]($ishBackgroundTask.PSobject.Properties.name -match "modificationdate") | Should -Be $true
+			$ishBackgroundTask.modificationdate -like "*/*" | Should -Be $false  # It should be sortable date format: yyyy-MM-ddTHH:mm:ss
 		}
 		It "Parameter RequestedMetadata PipelineObjectPreference=Off" {
 		    $pipelineObjectPreference = $ishSession.PipelineObjectPreference
 			$ishSession.PipelineObjectPreference = "Off"
 			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter All -RequestedMetadata $allMetadata)[0]
-			$ishBackgroundTask.GetType().Name | Should BeExactly "IshBackgroundTask"
-			[bool]($ishBackgroundTask.PSobject.Properties.name -match "status_task_element") | Should Be $false
-			[bool]($ishBackgroundTask.PSobject.Properties.name -match "userid_task_element") | Should Be $false
-			[bool]($ishBackgroundTask.PSobject.Properties.name -match "modificationdate") | Should Be $false
+			$ishBackgroundTask.GetType().Name | Should -BeExactly "IshBackgroundTask"
+			[bool]($ishBackgroundTask.PSobject.Properties.name -match "status_task_element") | Should -Be $false
+			[bool]($ishBackgroundTask.PSobject.Properties.name -match "userid_task_element") | Should -Be $false
+			[bool]($ishBackgroundTask.PSobject.Properties.name -match "modificationdate") | Should -Be $false
 			$ishSession.PipelineObjectPreference = $pipelineObjectPreference
 		}
 		It "Parameter MetadataFilter Filter to exactly one" {
@@ -165,29 +169,29 @@ Describe “Get-IshBackgroundTask" -Tags "Create" {
 			                  Set-IshMetadataFilterField -IshSession $ishSession -Level Task -Name TASKID -ValueType Element -Value ($ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name TASKID)
 			$ishBackgroundTaskArray = Get-IshBackgroundTask -IshSession $ishSession -MetadataFilter $filterMetadata
 			#Write-Host ("ishBackgroundTask.IshRef["+ $ishBackgroundTask.IshRef + "] ishBackgroundTaskArray.IshRef["+ $ishBackgroundTask.IshRef + "]")
-			$ishBackgroundTaskArray.Count -ge 1 | Should Be $true  # earlier on, also filter on HISTORYID, but that is not always filled in, even with the windows service off
+			$ishBackgroundTaskArray.Count -ge 1 | Should -Be $true  # earlier on, also filter on HISTORYID, but that is not always filled in, even with the windows service off
 		}
 		It "Parameter IshBackgroundTask invalid" {
-			{ Get-IshBackgroundTask -IshSession $ishSession -IshBackgroundTask "INVALIDISHBACKGROUNDTASK" } | Should Throw
+			{ Get-IshBackgroundTask -IshSession $ishSession -IshBackgroundTask "INVALIDISHBACKGROUNDTASK" } | Should -Throw
 		}
 		It "Parameter IshBackgroundTask Single" {
 			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter Current)[0]
 			$taskId = $ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name TASKID
 			$ishBackgroundTaskArray = Get-IshBackgroundTask -IshSession $ishSession -IshBackgroundTask $ishBackgroundTask
-			$ishBackgroundTaskArray.Count -ge 1 | Should Be $true
-			$ishBackgroundTaskArray.IshRef | Should Be $taskId
+			$ishBackgroundTaskArray.Count -ge 1 | Should -Be $true
+			$ishBackgroundTaskArray.IshRef | Should -Be $taskId
 		}
-		<# TODO It "Parameter IshBackgroundTask Multiple" {
+		<# TODO [Could] It "Parameter IshBackgroundTask Multiple" {
 		}
 		#>
 		It "Pipeline IshBackgroundTask Single" {
 			$ishBackgroundTask = (Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter Current)[0]
 			$taskId = $ishBackgroundTask | Get-IshMetadataField -IshSession $ishSession -Level Task -Name TASKID
 			$ishBackgroundTaskArray = $ishBackgroundTask | Get-IshBackgroundTask -IshSession $ishSession
-			$ishBackgroundTaskArray.Count -ge 1 | Should Be $true
-			$ishBackgroundTaskArray.IshRef | Should Be $taskId
+			$ishBackgroundTaskArray.Count -ge 1 | Should -Be $true
+			$ishBackgroundTaskArray.IshRef | Should -Be $taskId
 		}
-		<# TODO It "Pipeline IshBackgroundTask Multiple" {
+		<# TODO [Could] It "Pipeline IshBackgroundTask Multiple" {
 		}
 		#>
 	}
@@ -195,9 +199,10 @@ Describe “Get-IshBackgroundTask" -Tags "Create" {
 }
 
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/AddIshBasline.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/AddIshBasline.Tests.ps1
@@ -1,87 +1,135 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshBaseline"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshBaseline"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Add-IshBaseline" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
-	Context “Add-IshBaseline ParameterGroup" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe "Add-IshBaseline" -Tags "Create" {
+	Context "Add-IshBaseline ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshBaseline -IShSession "INVALIDISHSESSION" -Name "INVALIDBASELINENAME" } | Should Throw
+			{ Add-IshBaseline -IShSession "INVALIDISHSESSION" -Name "INVALIDBASELINENAME" } | Should -Throw
 		}
 	}
-
-	Context “Add-IshBaseline ParameterGroup" {
+	Context "Add-IshBaseline ParameterGroup" {
 		It "GetType().Name" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
 			$ishObject = Add-IshBaseline -Name $baselineName
-			(Get-IshMetadataField -IshObject $ishObject -Level None -Name "FISHDOCUMENTRELEASE").Length -gt 0 | Should Be $true
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.Count | Should Be 1
+			(Get-IshMetadataField -IshObject $ishObject -Level None -Name "FISHDOCUMENTRELEASE").Length -gt 0 | Should -Be $true
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.Count | Should -Be 1
 		}
 		It "GetType().Name with optional IshSession" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
 			$ishObject = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Level None -Name "FISHDOCUMENTRELEASE").Length -gt 0 | Should Be $true
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.Count | Should Be 1
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.fishdocumentrelease.Length -ge 1 | Should Be $true 
-			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should Be $true 
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Level None -Name "FISHDOCUMENTRELEASE").Length -gt 0 | Should -Be $true
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.Count | Should -Be 1
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.fishdocumentrelease.Length -ge 1 | Should -Be $true 
+			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should -Be $true 
 		}
 	}
-
-	Context “Add-IshBaseline IshObjectsGroup" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
-		              Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
-		              Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
-		              Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
-		              Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
-		$ishObjectE = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
-		              Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
-		$ishObjectF = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
-		              Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
-		Remove-IshBaseline -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
-		Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (...A12/10/2016 16:47:16)."
+	Context "Add-IshBaseline IshObjectsGroup" {
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			Remove-IshBaseline -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
+			Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (...A12/10/2016 16:47:16)."
+		}
 		It "Parameter IshObject invalid" {
-			{ Add-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should Throw
+			{ Add-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should -Throw
 		}
 		It "Parameter IshObject Single" {
 			$ishObjects = Add-IshBaseline -IshSession $ishSession -IshObject $ishObjectA
 			$ishObjects | Remove-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple" {
 			$ishObjects = Add-IshBaseline -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)
 			$ishObjects | Remove-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishObjects = $ishObjectD | Add-IshBaseline -IshSession $ishSession
 			$ishObjects | Remove-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishObjects = @($ishObjectE,$ishObjectF) | Add-IshBaseline -IshSession $ishSession
 			$ishObjects | Remove-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
+		}
+	}
+	Context "Add-IshBaseline IshObjectsGroup" {
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshBaseline -IshSession $ishSession -Name $baselineName | 
+						Get-IshBaseline -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME")
+			Remove-IshBaseline -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
+			Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (...A12/10/2016 16:47:16)."
+		}
+		It "Parameter IshObject invalid" {
+			{ Add-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should -Throw
+		}
+		It "Parameter IshObject Single" {
+			$ishObjects = Add-IshBaseline -IshSession $ishSession -IshObject $ishObjectA
+			$ishObjects | Remove-IshBaseline -IshSession $ishSession
+			$ishObjects.Count | Should -Be 1
+		}
+		It "Parameter IshObject Multiple" {
+			$ishObjects = Add-IshBaseline -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)
+			$ishObjects | Remove-IshBaseline -IshSession $ishSession
+			$ishObjects.Count | Should -Be 2
+		}
+		It "Pipeline IshObject Single" {
+			$ishObjects = $ishObjectD | Add-IshBaseline -IshSession $ishSession
+			$ishObjects | Remove-IshBaseline -IshSession $ishSession
+			$ishObjects.Count | Should -Be 1
+		}
+		It "Pipeline IshObject Multiple" {
+			$ishObjects = @($ishObjectE,$ishObjectF) | Add-IshBaseline -IshSession $ishSession
+			$ishObjects | Remove-IshBaseline -IshSession $ishSession
+			$ishObjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$baselines = Find-IshBaseline -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "NAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshBaseline -IshSession $ishSession -IshObject $baselines } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/FindIshBaseline.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/FindIshBaseline.Tests.ps1
@@ -1,72 +1,74 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Find-IshBaseline"
-try {
+BeforeAll {
+	$cmdletName = "Find-IshBaseline"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Find-IshBaseline" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
-
-	$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType ISHPublication -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	
-						 
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+		$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType ISHPublication -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+	}
 	Context "Find-IshBaseline ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Find-IshBaseline -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Find-IshBaseline -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Find-IshBaseline returns IshBaseline object" {
-		# Creating a publicationoutput, which implicitly creates a fresh baseline
-		$metadata = Set-IshMetadataField -IShSession $ishSession -Name "FTITLE" -Level Logical -Value "$cmdletName Pub" |
-		Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-		Set-IshMetadataField -IShSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution |
-		Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSTATUS" -Level Lng -ValueType Element -Value "VPUBSTATUSTOBEPUBLISHED"
-		$ishPublicationOutput = Add-IshPublicationOutput -IshSession $ishSession -FolderId $ishFolderCmdlet.IshFolderRef -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $metadata
-		$baselineId =  $ishPublicationOutput | 
-		               Get-IshPublicationOutput -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element) |
-					   Get-IshMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element
-					   
-		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINEACTIVE" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -ValueType Element |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHLABELRELEASED" -ValueType Element
-		$metadataFilter = Set-IshMetadataFilterField -IShSession $ishSession -Name "NAME" -Level None -FilterOperator Equal -Value $baselineId
+		BeforeAll {
+			# Creating a publicationoutput, which implicitly creates a fresh baseline
+			$metadata = Set-IshMetadataField -IShSession $ishSession -Name "FTITLE" -Level Logical -Value "$cmdletName Pub" |
+			Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+			Set-IshMetadataField -IShSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution |
+			Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSTATUS" -Level Lng -ValueType Element -Value "VPUBSTATUSTOBEPUBLISHED"
+			$ishPublicationOutput = Add-IshPublicationOutput -IshSession $ishSession -FolderId $ishFolderCmdlet.IshFolderRef -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $metadata
+			$baselineId =  $ishPublicationOutput | 
+						Get-IshPublicationOutput -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element) |
+						Get-IshMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element
+						
+			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINEACTIVE" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -ValueType Element |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHLABELRELEASED" -ValueType Element
+			$metadataFilter = Set-IshMetadataFilterField -IShSession $ishSession -Name "NAME" -Level None -FilterOperator Equal -Value $baselineId
+		}
 		It "Parameter IshSession explicit" {
 			$ishObject = Find-IshBaseline -IShSession $ishSession -RequestedMetadata $requestedMetadata | 
 		                 Where-Object -Property IshRef -EQ -Value $baselineId
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.IshRef -ge 0 | Should Be $true
-			$ishObject.IshType | Should Not BeNullOrEmpty
-			$ishObject.IshField | Should Not BeNullOrEmpty
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.fishdocumentrelease.Length -ge 1 | Should Be $true 
-			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should Be $true 
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.IshRef -ge 0 | Should -Be $true
+			$ishObject.IshType | Should -Not -BeNullOrEmpty
+			$ishObject.IshField | Should -Not -BeNullOrEmpty
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.fishdocumentrelease.Length -ge 1 | Should -Be $true 
+			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should -Be $true 
 		}
 		It "Parameter IshSession/RequestedMetadata implicit" {
 			$ishObject = Find-IshBaseline | 
 		                 Where-Object -Property IshRef -EQ -Value $baselineId
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.IshRef -ge 0 | Should Be $true
-			$ishObject.IshType | Should Not BeNullOrEmpty
-			$ishObject.IshField | Should Not BeNullOrEmpty
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.IshRef -ge 0 | Should -Be $true
+			$ishObject.IshType | Should -Not -BeNullOrEmpty
+			$ishObject.IshField | Should -Not -BeNullOrEmpty
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshPublicationOutput -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/GetIshBaseline.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/GetIshBaseline.Tests.ps1
@@ -1,101 +1,105 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshBaseline"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshBaseline"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Get-IshBaseline" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
-
-	$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType ISHPublication -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	
-						 
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+		$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType ISHPublication -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+	}
 	Context "Get-IshBaseline ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshBaseline -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Get-IshBaseline -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshBaseline returns IshBaseline object" {
-		# Creating a publicationoutput, which implicitly creates a fresh baseline
-		$metadata = Set-IshMetadataField -IShSession $ishSession -Name "FTITLE" -Level Logical -Value "$cmdletName Pub" |
-		Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-		Set-IshMetadataField -IShSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution |
-		Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSTATUS" -Level Lng -ValueType Element -Value "VPUBSTATUSTOBEPUBLISHED"
-		$ishPublicationOutput = Add-IshPublicationOutput -IshSession $ishSession -FolderId $ishFolderCmdlet.IshFolderRef -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $metadata
-		$baselineId =  $ishPublicationOutput | 
-		               Get-IshPublicationOutput -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element) |
-					   Get-IshMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element
-					   
-		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINEACTIVE" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -ValueType Element |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHLABELRELEASED" -ValueType Element
-		$metadataFilter = Set-IshMetadataFilterField -IShSession $ishSession -Name "NAME" -Level None -FilterOperator Like -Value "%"
+		BeforeAll {
+			# Creating a publicationoutput, which implicitly creates a fresh baseline
+			$metadata = Set-IshMetadataField -IShSession $ishSession -Name "FTITLE" -Level Logical -Value "$cmdletName Pub" |
+			Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+			Set-IshMetadataField -IShSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution |
+			Set-IshMetadataField -IShSession $ishSession -Name "FISHPUBSTATUS" -Level Lng -ValueType Element -Value "VPUBSTATUSTOBEPUBLISHED"
+			$ishPublicationOutput = Add-IshPublicationOutput -IshSession $ishSession -FolderId $ishFolderCmdlet.IshFolderRef -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $metadata
+			$baselineId =  $ishPublicationOutput | 
+						Get-IshPublicationOutput -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element) |
+						Get-IshMetadataField -IshSession $ishSession -Name "FISHBASELINE" -Level Version -ValueType Element
+						
+			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBASELINEACTIVE" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -ValueType Element |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHLABELRELEASED" -ValueType Element
+			$metadataFilter = Set-IshMetadataFilterField -IShSession $ishSession -Name "NAME" -Level None -FilterOperator Like -Value "%"
+		}
 		It "Parameter IshSession explicit" {
 			$ishObject = Get-IshBaseline -IShSession $ishSession -Id $baselineId -RequestedMetadata $requestedMetadata -MetadataFilter $metadataFilter
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.IshRef -ge 0 | Should Be $true
-			$ishObject.IshType | Should Not BeNullOrEmpty
-			$ishObject.IshField | Should Not BeNullOrEmpty
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.IshRef -ge 0 | Should -Be $true
+			$ishObject.IshType | Should -Not -BeNullOrEmpty
+			$ishObject.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter IshSession/RequestedMetadata implicit" {
 			$ishObject = Get-IshBaseline -Id $baselineId -MetadataFilter $metadataFilter
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.IshRef -ge 0 | Should Be $true
-			$ishObject.IshType | Should Not BeNullOrEmpty
-			$ishObject.IshField | Should Not BeNullOrEmpty
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.fishdocumentrelease.Length -ge 1 | Should Be $true 
-			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should Be $true 
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.IshRef -ge 0 | Should -Be $true
+			$ishObject.IshType | Should -Not -BeNullOrEmpty
+			$ishObject.IshField | Should -Not -BeNullOrEmpty
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.fishdocumentrelease.Length -ge 1 | Should -Be $true 
+			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should -Be $true 
 		}
 	}
 
 	Context "Get-IshBaseline IshObjectsGroup" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+		}
 		It "Parameter IshObject invalid" {
-			{ Get-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should Throw
+			{ Get-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should -Throw
 		}
 		It "Parameter IshObject Single" {
-			(Get-IshBaseline -IshSession $ishSession -IshObject $ishObjectA).IshRef.Length -ge 0 | Should Be $true
+			(Get-IshBaseline -IshSession $ishSession -IshObject $ishObjectA).IshRef.Length -ge 0 | Should -Be $true
 		}
 		It "Parameter IshObject Multiple" {
-			(Get-IshBaseline -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)).Count | Should Be 2
+			(Get-IshBaseline -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)).Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishObjects = $ishObjectD | Get-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishSession.MetadataBatchSize = 2
 			$ishObjects = @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD) | Get-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 4
+			$ishObjects.Count | Should -Be 4
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshPublicationOutput -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 	$baselines = Find-IshBaseline -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "NAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshBaseline -IshSession $ishSession -IshObject $baselines } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/GetIshBaselineItem.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/GetIshBaselineItem.Tests.ps1
@@ -1,88 +1,90 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshBaselineItem"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshBaselineItem"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Get-IshBaselineItem" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-
 	Context "Get-IshBaselineItem ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshBaselineItem -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Get-IshBaselineItem -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshBaselineItem returns IshBaselineItem object" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObject = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$ishObject = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObject -LogicalId "$cmdletName--AAA" -Version "1"
-		
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObject = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$ishObject = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObject -LogicalId "$cmdletName--AAA" -Version "1"
+		}
 		It "Parameter IshSession explicit" {
 			$ishBaselineItem = (Get-IshBaselineItem -IShSession $ishSession -IshObject $ishObject)[0]
-			$ishBaselineItem.GetType().Name | Should BeExactly "IshBaselineItem"
-			$ishBaselineItem.IshRef | Should Not BeNullOrEmpty
-			$ishBaselineItem.LogicalId | Should Not BeNullOrEmpty
-			$ishBaselineItem.Version | Should Not BeNullOrEmpty
-			$ishBaselineItem.Author | Should Not BeNullOrEmpty
-			$ishBaselineItem.CreatedOn | Should Not BeNullOrEmpty
-			$ishBaselineItem.CreatedOnAsSortableDateTime | Should Not BeNullOrEmpty
-			$ishBaselineItem.ModifiedOn | Should Not BeNullOrEmpty
-			$ishBaselineItem.ModifiedOnAsSortableDateTime | Should Not BeNullOrEmpty
+			$ishBaselineItem.GetType().Name | Should -BeExactly "IshBaselineItem"
+			$ishBaselineItem.IshRef | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.LogicalId | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.Version | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.Author | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.CreatedOn | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.CreatedOnAsSortableDateTime | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.ModifiedOn | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.ModifiedOnAsSortableDateTime | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter IshSession implicit" {
 			$ishBaselineItem = (Get-IshBaselineItem -IshObject $ishObject)[0]
-			$ishBaselineItem.GetType().Name | Should BeExactly "IshBaselineItem"
-			$ishBaselineItem.IshRef | Should Not BeNullOrEmpty
-			$ishBaselineItem.LogicalId | Should Not BeNullOrEmpty
-			$ishBaselineItem.Version | Should Not BeNullOrEmpty
-			$ishBaselineItem.Author | Should Not BeNullOrEmpty
-			$ishBaselineItem.CreatedOn | Should Not BeNullOrEmpty
-			$ishBaselineItem.CreatedOnAsSortableDateTime | Should Not BeNullOrEmpty
-			$ishBaselineItem.ModifiedOn | Should Not BeNullOrEmpty
-			$ishBaselineItem.ModifiedOnAsSortableDateTime | Should Not BeNullOrEmpty		
+			$ishBaselineItem.GetType().Name | Should -BeExactly "IshBaselineItem"
+			$ishBaselineItem.IshRef | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.LogicalId | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.Version | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.Author | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.CreatedOn | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.CreatedOnAsSortableDateTime | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.ModifiedOn | Should -Not -BeNullOrEmpty
+			$ishBaselineItem.ModifiedOnAsSortableDateTime | Should -Not -BeNullOrEmpty		
 		}
 	}
-
 	Context "Get-IshBaselineItem IshObjectsGroup" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA -LogicalId "$cmdletName--A" -Version "1"
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA -LogicalId "$cmdletName--AA" -Version "2"
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB -LogicalId "$cmdletName--B" -Version "1"
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB -LogicalId "$cmdletName--BB" -Version "2"
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC -LogicalId "$cmdletName--C" -Version "1"
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC -LogicalId "$cmdletName--CC" -Version "2"
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD -LogicalId "$cmdletName--D" -Version "1"
-		Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD -LogicalId "$cmdletName--DD" -Version "2"
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA -LogicalId "$cmdletName--A" -Version "1"
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA -LogicalId "$cmdletName--AA" -Version "2"
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB -LogicalId "$cmdletName--B" -Version "1"
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB -LogicalId "$cmdletName--BB" -Version "2"
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC -LogicalId "$cmdletName--C" -Version "1"
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC -LogicalId "$cmdletName--CC" -Version "2"
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD -LogicalId "$cmdletName--D" -Version "1"
+			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD -LogicalId "$cmdletName--DD" -Version "2"
+		}
 		It "Parameter IshObject invalid" {
-			{ Get-IshBaselineItem -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should Throw
+			{ Get-IshBaselineItem -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should -Throw
 		}
 		It "Parameter IshObject Single" {
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA).Count | Should Be 2
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA).Count | Should -Be 2
 		}
 		It "Parameter IshObject Multiple" {
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)).Count | Should Be 4
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)).Count | Should -Be 4
 		}
 		It "Pipeline IshObject Single" {
 			$ishBaselineItems = $ishObjectD | Get-IshBaselineItem -IshSession $ishSession
-			$ishBaselineItems.Count | Should Be 2
+			$ishBaselineItems.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishBaselineItems = @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD) | Get-IshBaselineItem -IshSession $ishSession
-			$ishBaselineItems.Count | Should Be 8
+			$ishBaselineItems.Count | Should -Be 8
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$baselines = Find-IshBaseline -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "NAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshBaseline -IshSession $ishSession -IshObject $baselines } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/SetIshBaseline.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/SetIshBaseline.Tests.ps1
@@ -1,83 +1,85 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Set-IshBaseline"
-try {
+BeforeAll {
+	$cmdletName = "Set-IshBaseline"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Set-IshBaseline" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
-	Context “Set-IshBaseline ParameterGroup" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe "Set-IshBaseline" -Tags "Create" {
+	Context "Set-IshBaseline ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Set-IshBaseline -IShSession "INVALIDISHSESSION" -Name "INVALIDBASELINENAME" } | Should Throw
+			{ Set-IshBaseline -IShSession "INVALIDISHSESSION" -Name "INVALIDBASELINENAME" } | Should -Throw
 		}
 	}
-
-	Context “Set-IshBaseline ParameterGroup" {
+	Context "Set-IshBaseline ParameterGroup" {
 		It "Parameter IshSession explicit" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
 			$ishObject = Add-IshBaseline -IshSession $ishSession -Name $baselineName
 			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value "$baselineName RENAMED"
 			$ishObject = Set-IshBaseline -IshSession $ishSession -Id $ishObject.IshRef -Metadata $metadata
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.Count | Should Be 1
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.Count | Should -Be 1
 		}
 		It "Parameter IshSession implicit" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
 			$ishObject = Add-IshBaseline -Name $baselineName
 			$metadata = Set-IshMetadataField -Name "FISHDOCUMENTRELEASE" -Level None -Value "$baselineName RENAMED"
 			$ishObject = Set-IshBaseline -Id $ishObject.IshRef -Metadata $metadata
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
-			$ishObject.Count | Should Be 1
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.fishdocumentrelease.Length -ge 1 | Should Be $true 
-			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should Be $true 
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
+			$ishObject.Count | Should -Be 1
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.fishdocumentrelease.Length -ge 1 | Should -Be $true 
+			$ishObject.fishdocumentrelease_none_element.StartsWith('GUID') | Should -Be $true 
 		}
 	}
 
-	Context “Set-IshBaseline IshObjectsGroup" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
-		$ishObjectE = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
-		$ishObjectF = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+	Context "Set-IshBaseline IshObjectsGroup" {
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+		}
 		It "Parameter IshObject invalid" {
-			{ Set-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should Throw
+			{ Set-IshBaseline -IShSession $ishSession -IshObject "INVALIDBASELINE" } | Should -Throw
 		}
 		It "Parameter IshObject Single" {
 			$ishObjectA = $ishObjectA | Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A Parameter IshObject Single RENAMED")
 			$ishObjects = Set-IshBaseline -IshSession $ishSession -IshObject $ishObjectA
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple" {
 			$ishObjectB = $ishObjectB | Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B Parameter IshObject Multiple RENAMED")
 			$ishObjectC = $ishObjectC | Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C Parameter IshObject Multiple RENAMED")
 			$ishObjects = Set-IshBaseline -IshSession $ishSession -IshObject @($ishObjectB,$ishObjectC)
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishObjectD = $ishObjectD | Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D Pipeline IshObject Single RENAMED")
 			$ishObjects = $ishObjectD | Set-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishObjectE = $ishObjectE | Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E Pipeline IshObject Multiple RENAMED")
 			$ishObjectF = $ishObjectF | Set-IshMetadataField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -Level None -Value ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F Pipeline IshObject Multiple RENAMED")
 			$ishObjects = @($ishObjectE,$ishObjectF) | Set-IshBaseline -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$baselines = Find-IshBaseline -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "NAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshBaseline -IshSession $ishSession -IshObject $baselines } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/SetIshBaselineItem.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Baseline/SetIshBaselineItem.Tests.ps1
@@ -1,93 +1,95 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Set-IshBaselineItem"
-try {
+BeforeAll {
+	$cmdletName = "Set-IshBaselineItem"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Set-IshBaselineItem" {
-	Write-Host "Initializing Test Data and Variables"
-
 	Context "Set-IshBaselineItem ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Set-IshBaselineItem -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Set-IshBaselineItem -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Set-IshBaselineItem returns IshObject" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObject = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$ishObject = Set-IshBaselineItem -IshObject $ishObject -LogicalId "$cmdletName--A" -Version "1"   # new
-		$ishObject = Set-IshBaselineItem -IshObject $ishObject -LogicalId "$cmdletName--AA" -Version "2"  # new
-		$ishObject = Set-IshBaselineItem -IshObject $ishObject -LogicalId "$cmdletName--AAA" -Version "3" # new
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObject = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$ishObject = Set-IshBaselineItem -IshObject $ishObject -LogicalId "$cmdletName--A" -Version "1"   # new
+			$ishObject = Set-IshBaselineItem -IshObject $ishObject -LogicalId "$cmdletName--AA" -Version "2"  # new
+			$ishObject = Set-IshBaselineItem -IshObject $ishObject -LogicalId "$cmdletName--AAA" -Version "3" # new
+		}
 		It "GetType()" {
-			$ishObject.GetType().Name | Should BeExactly "IshBaseline"
+			$ishObject.GetType().Name | Should -BeExactly "IshBaseline"
 		}
 		It "$ishObject.IshRef" {
-			$ishObject.IshRef | Should Not BeNullOrEmpty
+			$ishObject.IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "3 News" {
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObject).Count | Should Be 3
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObject).Count | Should -Be 3
 		}
 		It "3 News and 1 Update" {
 			Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObject -LogicalId "$cmdletName--A" -Version "4" # update
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObject).Count | Should Be 3
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObject).Count | Should -Be 3
 		}
 		It "3 News and 1 Update and 2 Removes" {
 			Remove-IshBaselineItem -IshSession $ishSession -IshObject $ishObject -LogicalId "$cmdletName--A" # remove
 			Remove-IshBaselineItem -IshSession $ishSession -IshObject $ishObject -LogicalId "$cmdletName--AA" # remove
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObject).Count | Should Be 1
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObject).Count | Should -Be 1
 		}
 	}
-
 	Context "Set-IshBaseline IshBaselineItemsGroup" {
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Single")
-		$ishObjectSingle = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$ishObjectSingle = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectSingle -LogicalId "$cmdletName--Single" -Version "1"
-		$ishObjectItemSingle = Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectSingle
-		$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Multiple")
-		$ishObjectMultiple = Add-IshBaseline -IshSession $ishSession -Name $baselineName
-		$ishObjectMultiple = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectMultiple -LogicalId "$cmdletName--Multiple" -Version "1"
-		$ishObjectMultiple = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectMultiple -LogicalId "$cmdletName--MultipleMultiple" -Version "2"
-		$ishObjectItemMultiple = Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectMultiple
-
+		BeforeAll {
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Single")
+			$ishObjectSingle = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$ishObjectSingle = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectSingle -LogicalId "$cmdletName--Single" -Version "1"
+			$ishObjectItemSingle = Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectSingle
+			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Multiple")
+			$ishObjectMultiple = Add-IshBaseline -IshSession $ishSession -Name $baselineName
+			$ishObjectMultiple = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectMultiple -LogicalId "$cmdletName--Multiple" -Version "1"
+			$ishObjectMultiple = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectMultiple -LogicalId "$cmdletName--MultipleMultiple" -Version "2"
+			$ishObjectItemMultiple = Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectMultiple
+		}
 		It "Setup IshBaselineItem Test Single GetType()" {
-			($ishObjectItemSingle).GetType().Name | Should BeExactly "IshBaselineItem"
+			($ishObjectItemSingle).GetType().Name | Should -BeExactly "IshBaselineItem"
 		}
 		It "Setup IshBaselineItem Test Multiple GetType()" {
-			($ishObjectItemMultiple).GetType().Name | Should BeExactly "Object[]"
+			($ishObjectItemMultiple).GetType().Name | Should -BeExactly "Object[]"
 		}
 		It "Parameter IshBaselineItem invalid" {
-			{ Set-IshBaselineItem -IShSession $ishSession -IshBaselineItem "INVALIDBASELINE" } | Should Throw
+			{ Set-IshBaselineItem -IShSession $ishSession -IshBaselineItem "INVALIDBASELINE" } | Should -Throw
 		}
 		It "Parameter IshBaselineItem Single" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
 			$ishObjectA = Add-IshBaseline -IshSession $ishSession -Name $baselineName
 			$ishObjectA = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA -IshBaselineItem $ishObjectItemSingle
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA).Count | Should Be 1
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectA).Count | Should -Be 1
 		}
 		It "Parameter IshBaselineItem Multiple" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
 			$ishObjectB = Add-IshBaseline -IshSession $ishSession -Name $baselineName
 			$ishObjectB = Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB -IshBaselineItem $ishObjectItemMultiple
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB).Count | Should Be 2
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectB).Count | Should -Be 2
 		}
 		It "Pipeline IshBaselineItem Single" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
 			$ishObjectC = Add-IshBaseline -IshSession $ishSession -Name $baselineName
 			$ishObjectC = $ishObjectItemSingle | Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC).Count | Should Be 1
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectC).Count | Should -Be 1
 		}
 		It "Pipeline IshBaselineItem Multiple" {
 			$baselineName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
 			$ishObjectD = Add-IshBaseline -IshSession $ishSession -Name $baselineName
 			$ishObjectD = $ishObjectItemMultiple | Set-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD
-			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD).Count | Should Be 2
+			(Get-IshBaselineItem -IshSession $ishSession -IshObject $ishObjectD).Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$baselines = Find-IshBaseline -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "FISHDOCUMENTRELEASE" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshBaseline -IshSession $ishSession -IshObject $baselines } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/AddIshDocumentObj.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/AddIshDocumentObj.Tests.ps1
@@ -1,113 +1,116 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshDocumentObj"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshDocumentObj"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Add-IshDocumentObj" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderOther = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "Other" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Add-IshDocumentObj" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	$tempFilePath = (New-TemporaryFile).FullName
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderOther = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "Other" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
+		$tempFilePath = (New-TemporaryFile).FullName
+	}
 	Context "Add-IshDocumentObj returns IshObject object (Topic)" {
-		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-		$ishObject = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+		BeforeAll {
+			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+			$ishObject = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+		}
 		It "GetType().Name" {
-			$ishObject.GetType().Name | Should BeExactly "IshDocumentObj"
+			$ishObject.GetType().Name | Should -BeExactly "IshDocumentObj"
 		}
 		It "ishObject.IshData" {
-			{ $ishObject.IshData } | Should Not Throw
+			{ $ishObject.IshData } | Should -Not -Throw
 		}
 		It "ishObject.IshField" {
-			$ishObject.IshField | Should Not BeNullOrEmpty
+			$ishObject.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.IshRef" {
-			$ishObject.IshRef | Should Not BeNullOrEmpty
+			$ishObject.IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.IshType" {
-			$ishObject.IshType | Should Not BeNullOrEmpty
+			$ishObject.IshType | Should -Not -BeNullOrEmpty
 		}
 		# Double check following 3 ReferenceType enum usage 
 		It "ishObject.ObjectRef" {
-			$ishObject.ObjectRef | Should Not BeNullOrEmpty
+			$ishObject.ObjectRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.VersionRef" {
-			$ishObject.VersionRef | Should Not BeNullOrEmpty
+			$ishObject.VersionRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.LngRef" {
-			$ishObject.LngRef | Should Not BeNullOrEmpty
+			$ishObject.LngRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject ConvertTo-Json" {
-			(ConvertTo-Json $ishObject).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishObject).Length -gt 2 | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObject.ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObject.ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObject.version_version_value.Length -ge 1 | Should Be $true 
+			$ishObject.version_version_value.Length -ge 1 | Should -Be $true 
 			#language
-			$ishObject.fstatus.Length -ge 1 | Should Be $true 
-			$ishObject.fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true 
-			$ishObject.doclanguage.Length -ge 1 | Should Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
-			$ishObject.doclanguage_lng_element.StartsWith('VLANGUAGE') | Should Be $true 
+			$ishObject.fstatus.Length -ge 1 | Should -Be $true 
+			$ishObject.fstatus_lng_element.StartsWith('VSTATUS') | Should -Be $true 
+			$ishObject.doclanguage.Length -ge 1 | Should -Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
+			$ishObject.doclanguage_lng_element.StartsWith('VLANGUAGE') | Should -Be $true 
 		}
 	}
-
-	Context “Add-IshDocumentObj ParameterGroupFileContent" {
+	Context "Add-IshDocumentObj ParameterGroupFileContent" {
 		It "Parameter IshSession/Lng/FileContent invalid" {
-			{ Add-IshDocumentObj -IShSession "INVALIDISHSESSION" -Lng "INVALIDLANGUAGE" -FileContent "INVALIDFILECONTENT" } | Should Throw
+			{ Add-IshDocumentObj -IShSession "INVALIDISHSESSION" -Lng "INVALIDLANGUAGE" -FileContent "INVALIDFILECONTENT" } | Should -Throw
 		}
 		It "Parameter Lng/FileContent invalid" {
-			{ Add-IshDocumentObj -IShSession $ishSession -Lng "INVALIDLANGUAGE" -FileContent "INVALIDFILECONTENT" } | Should Throw
+			{ Add-IshDocumentObj -IShSession $ishSession -Lng "INVALIDLANGUAGE" -FileContent "INVALIDFILECONTENT" } | Should -Throw
 		}
 		It "Parameter FileContent invalid" {
-			{ Add-IshDocumentObj -IShSession $ishSession -Lng $ishLng -FileContent "INVALIDFILECONTENT" } | Should Throw
+			{ Add-IshDocumentObj -IShSession $ishSession -Lng $ishLng -FileContent "INVALIDFILECONTENT" } | Should -Throw
 		}
 		It "All Parameters (Topic)" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Topic $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
 			    			    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
 			$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -LogicalId "MYOWNGENERATEDLOGICALIDTOPIC" -Version '2' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-			$ishObject.LngRef -gt 0 | Should Be $true
+			$ishObject.LngRef -gt 0 | Should -Be $true
 		}
 		It "All Parameters (Map)" {
 			$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Map $timestamp" |
 						      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
 			                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
 			$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -LogicalId "MYOWNGENERATEDLOGICALIDMAP" -Version '3' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMapFileContent
-			$ishObject.LngRef -gt 0 | Should Be $true
+			$ishObject.LngRef -gt 0 | Should -Be $true
 		}
 		It "All Parameters (Lib)" {
 			$ishLibMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Lib $timestamp" |
 						      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
 			    			  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
 			$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderLib -IshType ISHLibrary -LogicalId "MYOWNGENERATEDLOGICALIDLIB" -Version '4' -Lng $ishLng -Metadata $ishLibMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-			$ishObject.LngRef -gt 0 | Should Be $true
+			$ishObject.LngRef -gt 0 | Should -Be $true
 		}
 	}
-	
-	Context “Add-IshDocumentObj ParameterGroupFilePath" {
+	Context "Add-IshDocumentObj ParameterGroupFilePath" {
 		It "Parameter IshSession/Lng/FilePath invalid" {
-			{ Add-IshDocumentObj -IShSession "INVALIDISHSESSION" -Lng "INVALIDLANGUAGE" -FilePath "INVALIDFILEPATH" } | Should Throw
+			{ Add-IshDocumentObj -IShSession "INVALIDISHSESSION" -Lng "INVALIDLANGUAGE" -FilePath "INVALIDFILEPATH" } | Should -Throw
 		}
 		It "All Parameters (Image like EDTJPEG)" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Image $timestamp" |
@@ -125,7 +128,7 @@ Describe “Add-IshDocumentObj" -Tags "Create" {
 			}
 			$bmp.Save($tempFilePath, [System.Drawing.Imaging.ImageFormat]::Jpeg)
 			$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderImage -IshType ISHIllustration -LogicalId "MYOWNGENERATEDLOGICALIDIMAGE" -Version '5' -Lng $ishLng -Resolution $ishResolution -Metadata $ishImageMetadata -Edt "EDTJPEG" -FilePath $tempFilePath
-			$ishObject.LngRef -gt 0 | Should Be $true
+			$ishObject.LngRef -gt 0 | Should -Be $true
 		}
 		It "All Parameters (Other like EDT-TEXT)" {
 			$ishOtherMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Other $timestamp" |
@@ -133,16 +136,17 @@ Describe “Add-IshDocumentObj" -Tags "Create" {
 			    			    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
 			Get-Process | Out-File $tempFilePath
 			$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderOther -IshType ISHTemplate -LogicalId "MYOWNGENERATEDLOGICALIDOTHER" -Version '6' -Lng $ishLng -Metadata $ishOtherMetadata -Edt "EDT-TEXT" -FilePath $tempFilePath
-			$ishObject.LngRef -gt 0 | Should Be $true
+			$ishObject.LngRef -gt 0 | Should -Be $true
 		}
 	}
-
-	Context “Add-IshDocumentObj IshObjectsGroup" {
-		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+	Context "Add-IshDocumentObj IshObjectsGroup" {
+		BeforeAll {
+			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		}
 		It "Parameter IshObject invalid" {
-			{ Add-IshDocumentObj -IshSession $ishSession -IshFolder "INVALIDISHFOLDER" -IshObject "INVALIDISHOBJECT" } | Should Throw
+			{ Add-IshDocumentObj -IshSession $ishSession -IshFolder "INVALIDISHFOLDER" -IshObject "INVALIDISHOBJECT" } | Should -Throw
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			# Create an object, Delete it, Recreate it using parameter IshObject as if the incoming object came from another repository
@@ -150,7 +154,7 @@ Describe “Add-IshDocumentObj" -Tags "Create" {
 			             Get-IshDocumentObjData
 			Remove-IshDocumentObj -IshSession $ishSession -IshObject $ishObject
 			$ishObjectArray = Add-IshDocumentObj -IshFolder $ishFolderTopic -IshObject $ishObject
-			$ishObjectArray.Count | Should Be 1
+			$ishObjectArray.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 			# Create an object, Delete it, Recreate it using parameter IshObject as if the incoming object came from another repository
@@ -161,7 +165,7 @@ Describe “Add-IshDocumentObj" -Tags "Create" {
 			              Get-IshDocumentObjData
 			Remove-IshDocumentObj -IshObject $ishObjectB
 			$ishObjectArray = Add-IshDocumentObj -IshFolder $ishFolderTopic -IshObject @($ishObjectA,$ishObjectB)
-			$ishObjectArray.Count | Should Be 2
+			$ishObjectArray.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			# Create an object, Delete it, Recreate it using parameter IshObject as if the incoming object came from another repository
@@ -169,7 +173,7 @@ Describe “Add-IshDocumentObj" -Tags "Create" {
 			              Get-IshDocumentObjData -IshSession $ishSession
 			Remove-IshDocumentObj -IshSession $ishSession -IshObject $ishObjectC
 			$ishObjectArray = $ishObjectC | Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic
-			$ishObjectArray.Count | Should Be 1
+			$ishObjectArray.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			# Create an object, Delete it, Recreate it using parameter IshObject as if the incoming object came from another repository
@@ -180,17 +184,16 @@ Describe “Add-IshDocumentObj" -Tags "Create" {
 			$ishObjects = @($ishObjectD,$ishObjectE)
 			$ishObjects | Remove-IshDocumentObj -IshSession $ishSession
 			$ishObjectArray = $ishObjects | Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic
-			$ishObjects.Count -eq $ishObjectArray.Count | Should Be $true
+			$ishObjects.Count -eq $ishObjectArray.Count | Should -Be $true
 		}
 	}
-
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 	try { Remove-Item $tempFilePath -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/GetIshDocumentObjData.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/GetIshDocumentObjData.Tests.ps1
@@ -1,89 +1,89 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshDocumentObjData"
-try {
-	
+BeforeAll {
+	$cmdletName = "Get-IshDocumentObjData"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
 	$tempFolder = [System.IO.Path]::GetTempPath()
+}
+
 Describe "Get-IshDocumentObjData" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopicA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
-	$ishObjectLibraryA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderLib.IshFolderRef -IshType ISHLibrary -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
-
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+							Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectTopicA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+		$ishObjectLibraryA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderLib.IshFolderRef -IshType ISHLibrary -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+	}
 	Context "Get-IshDocumentObjData FolderPathGroup" {
 		It "Parameter IshSession/IshObject invalid" {
-			{ Get-IshDocumentObjData -IShSession "INVALIDISHSESSION" -IshObject "INVALIDISHOBJECT" } | Should Throw
-		}
-		$fileInfo = Get-IshDocumentObjData -IshSession $ishSession -IshObject $ishObjectTopicA -FolderPath (Join-Path $tempFolder $cmdletName)
-		It "GetType().Name" {
-			$fileInfo.GetType().Name | Should BeExactly "FileInfo"
+			{ Get-IshDocumentObjData -IShSession "INVALIDISHSESSION" -IshObject "INVALIDISHOBJECT" } | Should -Throw
 		}
 		It "FileInfo.Name contains 4 = signs" {
-			$fileInfo.Name -like "*=*=*=*=*.*" | Should Be $true
+			$fileInfo = Get-IshDocumentObjData -IshSession $ishSession -IshObject $ishObjectTopicA -FolderPath (Join-Path $tempFolder $cmdletName)
+			$fileInfo.GetType().Name | Should -BeExactly "FileInfo"
+			$fileInfo.Name -like "*=*=*=*=*.*" | Should -Be $true
 		}
 		It "Parameter IshFeature matching features (so everything equals source file)" {
 			$ishFeatures = Set-IshFeature -Name "ISHRemoteStringCond" -Value "StringOne" |
 			               Set-IshFeature -Name "ISHRemoteVersionCond" -Value "12.0.1"
 			$fileInfo = Get-IshDocumentObjData -IshSession $ishSession -IshObject $ishObjectTopicA -FolderPath (Join-Path $tempFolder $cmdletName) -IshFeature $ishFeatures
-			$fileContent = Get-Content $fileInfo
+			$fileContent = Get-Content $fileInfo -Raw
 			Write-Debug ("fileContent.Length[" + $fileContent.Length + "] fileContent.GetType()[" + $fileContent.GetType() + "] fileContent[" +$fileContent+"]")
-			($fileContent -like "*ISHRemoteStringCond*") | Should Be $true
+			($fileContent -like "*ISHRemoteStringCond*") | Should -Be $true
 		}
 		It "Parameter IshFeature not matching features (so everything filtered away)" {
 			$ishFeatures = Set-IshFeature -Name "INVALIDFEATURE" -Value "INVALIDVALUE"
 			$fileInfo = Get-IshDocumentObjData -IshSession $ishSession -IshObject $ishObjectTopicA -FolderPath (Join-Path $tempFolder $cmdletName) -IshFeature $ishFeatures
-			$fileContent = Get-Content $fileInfo
+			$fileContent = Get-Content $fileInfo -Raw 
 			Write-Debug ("fileContent.Length[" + $fileContent.Length + "] fileContent.GetType()[" + $fileContent.GetType() + "] fileContent[" +$fileContent+"]")
-			$fileContent -notlike "*ISHRemoteStringCond*" | Should Be $true
+			$fileContent -notlike "*ISHRemoteStringCond*" | Should -Be $true
 		}
 	}
-
 	Context "Get-IshDocumentObjData IshObjectGroup" {
 		It "GetType().Name" {
 			$ishobjects = Get-IshDocumentObjData -IshSession $ishSession -IshObject @($ishObjectTopicA,$ishObjectLibraryA)
-			$ishobjects.GetType().Name | Should BeExactly "Object[]"
+			$ishobjects.GetType().Name | Should -BeExactly "Object[]"
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			$ishobjects = Get-IshDocumentObjData -IshObject $ishObjectTopicA
-			$ishobjects.Count | Should Be 1
+			$ishobjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 			$ishobjects = Get-IshDocumentObjData -IshObject @($ishObjectTopicA,$ishObjectLibraryA)
-			$ishobjects.Count | Should Be 2
+			$ishobjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishobjects = $ishObjectTopicA | Get-IshDocumentObjData -IshSession $ishSession
-			$ishobjects.Count | Should Be 1
+			$ishobjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishobjects = @($ishObjectTopicA,$ishObjectLibraryA) | Get-IshDocumentObjData -IshSession $ishSession
-			$ishobjects.Count | Should Be 2
+			$ishobjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 	try { Remove-Item (Join-Path $tempFolder $cmdletName) -Recurse -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/GetIshDocumentObjFolderLocation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/GetIshDocumentObjFolderLocation.Tests.ps1
@@ -1,76 +1,80 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshDocumentObjFolderLocation"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshDocumentObjFolderLocation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshDocumentObjFolderLocation" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Get-IshDocumentObjFolderLocation" -Tags "Read" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectTopicA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
-	$ishObjectLibraryA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderLib.IshFolderRef -IshType ISHLibrary -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+							Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectTopicA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+		$ishObjectLibraryA = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderLib.IshFolderRef -IshType ISHLibrary -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+	}
 	Context "Get-IshDocumentObjFolderLocation ParameterGroup" {
-		It "Parameter IshSession/LogicalId invalid" {
-			{ Get-IshDocumentObjFolderLocation -IShSession "INVALIDISHSESSION" -LogicalId "INVALIDLOGICALID" } | Should Throw
+		BeforeAll {
+			$folderPath = Get-IShDocumentObjFolderLocation -IshSession $ishSession -LogicalId $ishObjectTopicA.IshRef
 		}
-		$folderPath = Get-IShDocumentObjFolderLocation -IshSession $ishSession -LogicalId $ishObjectTopicA.IshRef
+		It "Parameter IshSession/LogicalId invalid" {
+			{ Get-IshDocumentObjFolderLocation -IShSession "INVALIDISHSESSION" -LogicalId "INVALIDLOGICALID" } | Should -Throw
+		}
 		It "GetType().Name" {
-			$folderPath.GetType().Name | Should BeExactly "String"
+			$folderPath.GetType().Name | Should -BeExactly "String"
 		}
 		It "Parameter LogicalId Single" {
-			$folderPath | Should BeExactly (Join-Path (Join-Path $folderTestRootPath $cmdletName) "Topic")
+			$folderPath | Should -BeExactly (Join-Path (Join-Path $folderTestRootPath $cmdletName) "Topic")
 		}
 		It "Leading IshSession.FolderPathSeparator" {
-			$folderPath[0] | Should Be $ishSession.FolderPathSeparator
+			$folderPath[0] | Should -Be $ishSession.FolderPathSeparator
 		}
 	}
-
 	Context "Get-IshDocumentObjFolderLocation IshObjectGroup" {
 		It "GetType().Name" {
 			$folderPathArray = Get-IShDocumentObjFolderLocation -IshSession $ishSession -IshObject @($ishObjectTopicA,$ishObjectLibraryA)
-			$folderPathArray.GetType().Name | Should BeExactly "Object[]"
+			$folderPathArray.GetType().Name | Should -BeExactly "Object[]"
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			$folderPathArray = Get-IShDocumentObjFolderLocation -IshObject $ishObjectTopicA
-			$folderPathArray.Count | Should Be 1
+			$folderPathArray.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 			$folderPathArray = Get-IShDocumentObjFolderLocation -IshObject @($ishObjectTopicA,$ishObjectLibraryA)
-			$folderPathArray.Count | Should Be 2
+			$folderPathArray.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$folderPathArray = $ishObjectTopicA | Get-IShDocumentObjFolderLocation -IshSession $ishSession
-			$folderPathArray.Count | Should Be 1
+			$folderPathArray.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$folderPathArray = @($ishObjectTopicA,$ishObjectLibraryA) | Get-IShDocumentObjFolderLocation -IshSession $ishSession
-			$folderPathArray.Count | Should Be 2
+			$folderPathArray.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 	try { Remove-Item $tempFilePath -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/SearchIshDocumentObj.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/SearchIshDocumentObj.Tests.ps1
@@ -1,162 +1,165 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Search-IshDocumentObj"
-try {
-	
+BeforeAll {
+	$cmdletName = "Search-IshDocumentObj"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
 	$tempFolder = [System.IO.Path]::GetTempPath()
+}
+	
 Describe "Search-IshDocumentObjData" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+	}
 	Context "Search-IshDocumentObj requires server-side 'Trisoft InfoShare SolrLucene' service running" {
 		It "Is 'Trisoft InfoShare SolrLucene' running?" {
-			{ Search-IshDocumentObj -SimpleQuery "Testing if 'Trisoft InfoShare SolrLucene' is up-and-running" } | Should Not Throw
+			{ Search-IshDocumentObj -SimpleQuery "Testing if 'Trisoft InfoShare SolrLucene' is up-and-running" } | Should -Not -Throw
 		}
 	}
-
 	Context "Search-IshDocumentObj SimpleQueryGroup" {
 		It "Parameter IshSession invalid" {
-			{ Search-IshDocumentObj -IShSession "INVALIDISHSESSION" -SimpleQuery "INVALIDQUERY IS NOT INVALID IT IS JUST A QUERY" } | Should Throw
+			{ Search-IshDocumentObj -IShSession "INVALIDISHSESSION" -SimpleQuery "INVALIDQUERY IS NOT INVALID IT IS JUST A QUERY" } | Should -Throw
 		}
 		It "Parameter MaxHitsToReturn invalid" {
-			{ Search-IshDocumentObj -MaxHitsToReturn "INVALIDMAXHITSTORETURN" -SimpleQuery "INVALIDQUERY IS NOT INVALID IT IS JUST A QUERY" } | Should Throw
-			{ Search-IshDocumentObj -MaxHitsToReturn -3 -SimpleQuery "INVALIDQUERY IS NOT INVALID IT IS JUST A QUERY" } | Should Throw
+			{ Search-IshDocumentObj -MaxHitsToReturn "INVALIDMAXHITSTORETURN" -SimpleQuery "INVALIDQUERY IS NOT INVALID IT IS JUST A QUERY" } | Should -Throw
+			{ Search-IshDocumentObj -MaxHitsToReturn -3 -SimpleQuery "INVALIDQUERY IS NOT INVALID IT IS JUST A QUERY" } | Should -Throw
 		}
 		It "Parameter MaxHitsToReturn" {
 			$ishObject = Search-IshDocumentObj -MaxHitsToReturn 3 -SimpleQuery "*"
-			$ishObject.Count -eq 3 | Should Be $true 
+			$ishObject.Count -eq 3 | Should -Be $true 
 		}
 		It "Parameter RequestedMetadata" {
 			$requestedMetadata = Set-IshRequestedMetadataField -Level Lng -Name FISHSTATUSTYPE
 			$ishObject = Search-IshDocumentObj -IShSession $ishSession -MaxHitsToReturn 2 -SimpleQuery "*" -RequestedMetadata $requestedMetadata
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObject[0].ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObject[0].ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObject[0].version_version_value.Length -ge 1 | Should Be $true 
+			$ishObject[0].version_version_value.Length -ge 1 | Should -Be $true 
 			#language
-			$ishObject[0].fstatus.Length -ge 1 | Should Be $true 
-			$ishObject[0].fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true 
-			$ishObject[0].doclanguage.Length -ge 1 | Should Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
-			$ishObject[0].doclanguage_lng_element.StartsWith('VLANGUAGE') | Should Be $true
-			$ishObject[0].fishstatustype -ge 0  | Should Be $true  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
+			$ishObject[0].fstatus.Length -ge 1 | Should -Be $true 
+			$ishObject[0].fstatus_lng_element.StartsWith('VSTATUS') | Should -Be $true 
+			$ishObject[0].doclanguage.Length -ge 1 | Should -Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
+			$ishObject[0].doclanguage_lng_element.StartsWith('VLANGUAGE') | Should -Be $true
+			$ishObject[0].fishstatustype -ge 0  | Should -Be $true  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
 		}
 		It "Parameter Count" {
 			$count = Search-IshDocumentObj -SimpleQuery "*" -Count
-			$count -ge 0 | Should Be $true 
+			$count -ge 0 | Should -Be $true 
 		}
 		It "Search-IshDocumentObj returns IshObject objects" {
 			$ishObject = Search-IshDocumentObj -IShSession $ishSession -MaxHitsToReturn 2 -SimpleQuery "*"
-			$ishObject[0].IshField | Should Not BeNullOrEmpty
-			$ishObject[0].IshRef | Should Not BeNullOrEmpty
-			$ishObject[0].IshType | Should Not BeNullOrEmpty
-			$ishObject[0].ObjectRef | Should Not BeNullOrEmpty
-			$ishObject[0].VersionRef | Should Not BeNullOrEmpty
-			$ishObject[0].LngRef | Should Not BeNullOrEmpty
-			$ishObject[0].fishstatustype -ge 0  | Should Be $false  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
+			$ishObject[0].IshField | Should -Not -BeNullOrEmpty
+			$ishObject[0].IshRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].IshType | Should -Not -BeNullOrEmpty
+			$ishObject[0].ObjectRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].VersionRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].LngRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].fishstatustype -ge 0  | Should -Be $false  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
 		}
 	}
-
 	Context "Search-IshDocumentObj XmlQueryQueryGroup" {
-		$xmlQueryLatestVersion = @"
-		<ishquery>
-		  <and><ishfield name='ISHANYWHERE' level='none' ishoperator='contains'>*</ishfield></and>
-		  <ishsort>
-			<ishsortfield name='ISHSCORE' level='none' ishorder='d'/>
-			<ishsortfield name='FTITLE' level='logical' ishorder='d'/>
-		  </ishsort>
-		  <ishobjectfilters>
-			<ishversionfilter>LatestVersion</ishversionfilter>
-			<ishtypefilter>ISHModule</ishtypefilter>
-			<ishtypefilter>ISHMasterDoc</ishtypefilter>
-			<ishtypefilter>ISHLibrary</ishtypefilter>
-			<ishtypefilter>ISHTemplate</ishtypefilter>
-			<ishtypefilter>ISHIllustration</ishtypefilter>
-			<ishlanguagefilter>#!#ISHRemoteParameter:UserLanguage#!#</ishlanguagefilter>
-		  </ishobjectfilters>
-		</ishquery>
+		BeforeAll {
+			$xmlQueryLatestVersion = @"
+			<ishquery>
+			<and><ishfield name='ISHANYWHERE' level='none' ishoperator='contains'>*</ishfield></and>
+			<ishsort>
+				<ishsortfield name='ISHSCORE' level='none' ishorder='d'/>
+				<ishsortfield name='FTITLE' level='logical' ishorder='d'/>
+			</ishsort>
+			<ishobjectfilters>
+				<ishversionfilter>LatestVersion</ishversionfilter>
+				<ishtypefilter>ISHModule</ishtypefilter>
+				<ishtypefilter>ISHMasterDoc</ishtypefilter>
+				<ishtypefilter>ISHLibrary</ishtypefilter>
+				<ishtypefilter>ISHTemplate</ishtypefilter>
+				<ishtypefilter>ISHIllustration</ishtypefilter>
+				<ishlanguagefilter>#!#ISHRemoteParameter:UserLanguage#!#</ishlanguagefilter>
+			</ishobjectfilters>
+			</ishquery>
 "@  # has to be on the margin, far-left
-		$xmlQueryLatestVersion = $xmlQueryLatestVersion -replace "#!#ISHRemoteParameter:UserLanguage#!#", $ishSession.UserLanguage
-		$xmlQueryAllVersions = @"
-		<ishquery>
-		  <and><ishfield name='ISHANYWHERE' level='none' ishoperator='contains'>*</ishfield></and>
-		  <ishsort>
-			<ishsortfield name='ISHSCORE' level='none' ishorder='d'/>
-			<ishsortfield name='FTITLE' level='logical' ishorder='d'/>
-		  </ishsort>
-		  <ishobjectfilters>
-			<ishversionfilter>AllVersions</ishversionfilter>
-			<ishtypefilter>ISHModule</ishtypefilter>
-			<ishtypefilter>ISHMasterDoc</ishtypefilter>
-			<ishtypefilter>ISHLibrary</ishtypefilter>
-			<ishtypefilter>ISHTemplate</ishtypefilter>
-			<ishtypefilter>ISHIllustration</ishtypefilter>
-			<ishlanguagefilter>#!#ISHRemoteParameter:UserLanguage#!#</ishlanguagefilter>
-		  </ishobjectfilters>
-		</ishquery>
+			$xmlQueryLatestVersion = $xmlQueryLatestVersion -replace "#!#ISHRemoteParameter:UserLanguage#!#", $ishSession.UserLanguage
+			$xmlQueryAllVersions = @"
+			<ishquery>
+			<and><ishfield name='ISHANYWHERE' level='none' ishoperator='contains'>*</ishfield></and>
+			<ishsort>
+				<ishsortfield name='ISHSCORE' level='none' ishorder='d'/>
+				<ishsortfield name='FTITLE' level='logical' ishorder='d'/>
+			</ishsort>
+			<ishobjectfilters>
+				<ishversionfilter>AllVersions</ishversionfilter>
+				<ishtypefilter>ISHModule</ishtypefilter>
+				<ishtypefilter>ISHMasterDoc</ishtypefilter>
+				<ishtypefilter>ISHLibrary</ishtypefilter>
+				<ishtypefilter>ISHTemplate</ishtypefilter>
+				<ishtypefilter>ISHIllustration</ishtypefilter>
+				<ishlanguagefilter>#!#ISHRemoteParameter:UserLanguage#!#</ishlanguagefilter>
+			</ishobjectfilters>
+			</ishquery>
 "@  # has to be on the margin, far-left
-		$xmlQueryAllVersions = $xmlQueryAllVersions -replace "#!#ISHRemoteParameter:UserLanguage#!#", $ishSession.UserLanguage
+			$xmlQueryAllVersions = $xmlQueryAllVersions -replace "#!#ISHRemoteParameter:UserLanguage#!#", $ishSession.UserLanguage
+		}
 		It "Parameter IshSession invalid" {
-			{ Search-IshDocumentObj -IShSession "INVALIDISHSESSION" -XmlQuery "INVALIDQUERY" } | Should Throw
+			{ Search-IshDocumentObj -IShSession "INVALIDISHSESSION" -XmlQuery "INVALIDQUERY" } | Should -Throw
 		}
 		It "Parameter XmlQuery invalid" {
-			{ Search-IshDocumentObj -IShSession $ishSession -XmlQuery "INVALIDQUERY" } | Should Throw
+			{ Search-IshDocumentObj -IShSession $ishSession -XmlQuery "INVALIDQUERY" } | Should -Throw
 		}
 		It "Parameter MaxHitsToReturn invalid" {
-			{ Search-IshDocumentObj -MaxHitsToReturn "INVALIDMAXHITSTORETURN" -XmlQuery $xmlQueryLatestVersion } | Should Throw
-			{ Search-IshDocumentObj -MaxHitsToReturn -4 -XmlQuery $xmlQueryLatestVersion } | Should Throw
+			{ Search-IshDocumentObj -MaxHitsToReturn "INVALIDMAXHITSTORETURN" -XmlQuery $xmlQueryLatestVersion } | Should -Throw
+			{ Search-IshDocumentObj -MaxHitsToReturn -4 -XmlQuery $xmlQueryLatestVersion } | Should -Throw
 		}
 		It "Parameter MaxHitsToReturn" {
 			$ishObject = Search-IshDocumentObj -MaxHitsToReturn 4 -XmlQuery $xmlQueryLatestVersion
-			$ishObject.Count -eq 4 | Should Be $true 
+			$ishObject.Count -eq 4 | Should -Be $true 
 		}
 		It "Parameter RequestedMetadata" {
 			$requestedMetadata = Set-IshRequestedMetadataField -Level Lng -Name FISHSTATUSTYPE
 			$ishObject = Search-IshDocumentObj -IShSession $ishSession -MaxHitsToReturn 2 -XmlQuery $xmlQueryLatestVersion -RequestedMetadata $requestedMetadata
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObject[0].ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObject[0].ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObject[0].version_version_value.Length -ge 1 | Should Be $true 
+			$ishObject[0].version_version_value.Length -ge 1 | Should -Be $true 
 			#language
-			$ishObject[0].fstatus.Length -ge 1 | Should Be $true 
-			$ishObject[0].fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true 
-			$ishObject[0].doclanguage.Length -ge 1 | Should Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
-			$ishObject[0].doclanguage_lng_element.StartsWith('VLANGUAGE') | Should Be $true
-			$ishObject[0].fishstatustype -ge 0  | Should Be $true  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
+			$ishObject[0].fstatus.Length -ge 1 | Should -Be $true 
+			$ishObject[0].fstatus_lng_element.StartsWith('VSTATUS') | Should -Be $true 
+			$ishObject[0].doclanguage.Length -ge 1 | Should -Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
+			$ishObject[0].doclanguage_lng_element.StartsWith('VLANGUAGE') | Should -Be $true
+			$ishObject[0].fishstatustype -ge 0  | Should -Be $true  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
 		}
 		It "Parameter Count" {
 			$count = Search-IshDocumentObj -XmlQuery $xmlQueryAllVersions -Count
-			$count -ge 0 | Should Be $true 
+			$count -ge 0 | Should -Be $true 
 		}
 		It "Search-IshDocumentObj returns IshObject objects" {
 			$ishObject = Search-IshDocumentObj -IShSession $ishSession -MaxHitsToReturn 2 -XmlQuery $xmlQueryLatestVersion
-			$ishObject[0].IshField | Should Not BeNullOrEmpty
-			$ishObject[0].IshRef | Should Not BeNullOrEmpty
-			$ishObject[0].IshType | Should Not BeNullOrEmpty
-			$ishObject[0].ObjectRef | Should Not BeNullOrEmpty
-			$ishObject[0].VersionRef | Should Not BeNullOrEmpty
-			$ishObject[0].LngRef | Should Not BeNullOrEmpty
-			$ishObject[0].fishstatustype -ge 0  | Should Be $false  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
+			$ishObject[0].IshField | Should -Not -BeNullOrEmpty
+			$ishObject[0].IshRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].IshType | Should -Not -BeNullOrEmpty
+			$ishObject[0].ObjectRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].VersionRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].LngRef | Should -Not -BeNullOrEmpty
+			$ishObject[0].fishstatustype -ge 0  | Should -Be $false  # Basic does not return FISHSTATUSTYPE but extra RequestedMetadata parameter does
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/SetIshDocumentObj.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/DocumentObj/SetIshDocumentObj.Tests.ps1
@@ -1,122 +1,122 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Set-IshDocumentObj"
-
-
-#
-# Script-file scope auxiliary function
-#
-function script:CreateSquareImageBySideSize([int]$size)
-{
-	Add-Type -AssemblyName "System.Drawing"
-	$bmp = New-Object -TypeName System.Drawing.Bitmap($size, $size)
-	for ($i = 0; $i -lt $size; $i++)
-	{
-		for ($j = 0; $j -lt $size; $j++)
-		{
-			$bmp.SetPixel($i, $j, 'Red')
-		}
-	}
+BeforeAll {
+	$cmdletName = "Set-IshDocumentObj"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 	
-	return $bmp
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+	$tempFolder = [System.IO.Path]::GetTempPath()
+	#
+	# Script-file scope auxiliary function
+	#
+	function script:CreateSquareImageBySideSize([int]$size)
+	{
+		Add-Type -AssemblyName "System.Drawing"
+		$bmp = New-Object -TypeName System.Drawing.Bitmap($size, $size)
+		for ($i = 0; $i -lt $size; $i++)
+		{
+			for ($j = 0; $j -lt $size; $j++)
+			{
+				$bmp.SetPixel($i, $j, 'Red')
+			}
+		}
+		
+		return $bmp
+	}
 }
 
-try {
-$tempFolder = [System.IO.Path]::GetTempPath()
-Describe “Set-IshDocumentObj" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+Describe "Set-IshDocumentObj" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType ISHNone -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderOther = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "Other" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType ISHNone -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderOther = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "Other" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
-	# Create files with two images: 100*100 and 200*200
-	$tempFilePathImage100x100 = (New-TemporaryFile).FullName
-	$bmp = CreateSquareImageBySideSize -size 100
-	$bmp.Save($tempFilePathImage100x100, [System.Drawing.Imaging.ImageFormat]::Jpeg)
-	$tempFilePathImage200x200 = (New-TemporaryFile).FullName
-	$bmp = CreateSquareImageBySideSize -size 200
-	$bmp.Save($tempFilePathImage200x200, [System.Drawing.Imaging.ImageFormat]::Jpeg)
-	
+		# Create files with two images: 100*100 and 200*200
+		$tempFilePathImage100x100 = (New-TemporaryFile).FullName
+		$bmp = CreateSquareImageBySideSize -size 100
+		$bmp.Save($tempFilePathImage100x100, [System.Drawing.Imaging.ImageFormat]::Jpeg)
+		$tempFilePathImage200x200 = (New-TemporaryFile).FullName
+		$bmp = CreateSquareImageBySideSize -size 200
+		$bmp.Save($tempFilePathImage200x200, [System.Drawing.Imaging.ImageFormat]::Jpeg)
+	}
 	Context "Set-IshDocumentObj returns IshObject object (Topic)" {
-		
-		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-		$ishObjectToUpdate = Add-IshDocumentObj -IshSession $ishSession `
-												-FolderId $ishFolderTopic.IshFolderRef `
-												-IshType ISHModule `
-												-Lng $ishLng `
-												-Metadata $ishTopicMetadata `
-												-FileContent $ditaTopicFileContent
-		$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value "Updated topic title $timestamp"
-		$ishObject = Set-IshDocumentObj -IshSession $ishSession `
-										-LogicalId $ishObjectToUpdate.IshRef `
-										-Version $ishObjectToUpdate.version_version_value `
-										-Lng $ishObjectToUpdate.doclanguage `
-										-Metadata $ishMetadataFieldsSet
-										
+		BeforeAll {	
+			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+			$ishObjectToUpdate = Add-IshDocumentObj -IshSession $ishSession `
+													-FolderId $ishFolderTopic.IshFolderRef `
+													-IshType ISHModule `
+													-Lng $ishLng `
+													-Metadata $ishTopicMetadata `
+													-FileContent $ditaTopicFileContent
+			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value "Updated topic title $timestamp"
+			$ishObject = Set-IshDocumentObj -IshSession $ishSession `
+											-LogicalId $ishObjectToUpdate.IshRef `
+											-Version $ishObjectToUpdate.version_version_value `
+											-Lng $ishObjectToUpdate.doclanguage `
+											-Metadata $ishMetadataFieldsSet
+		}								
 		It "GetType().Name" {
-			$ishObject.GetType().Name | Should BeExactly "IshDocumentObj"
+			$ishObject.GetType().Name | Should -BeExactly "IshDocumentObj"
 		}
 		It "ishObject.IshData" {
-			{ $ishObject.IshData } | Should Not Throw
+			{ $ishObject.IshData } | Should -Not -Throw
 		}
 		It "ishObject.IshField" {
-			$ishObject.IshField | Should Not BeNullOrEmpty
+			$ishObject.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.IshRef" {
-			$ishObject.IshRef | Should Not BeNullOrEmpty
+			$ishObject.IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.IshType" {
-			$ishObject.IshType | Should Not BeNullOrEmpty
+			$ishObject.IshType | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.ObjectRef" {
-			$ishObject.ObjectRef | Should Not BeNullOrEmpty
+			$ishObject.ObjectRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.VersionRef" {
-			$ishObject.VersionRef | Should Not BeNullOrEmpty
+			$ishObject.VersionRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.LngRef" {
-			$ishObject.LngRef | Should Not BeNullOrEmpty
+			$ishObject.LngRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject ConvertTo-Json" {
-			(ConvertTo-Json $ishObject).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishObject).Length -gt 2 | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObject.ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObject.ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObject.version_version_value.Length -ge 1 | Should Be $true 
+			$ishObject.version_version_value.Length -ge 1 | Should -Be $true 
 			#language
-			$ishObject.fstatus.Length -ge 1 | Should Be $true 
-			$ishObject.fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true 
-			$ishObject.doclanguage.Length -ge 1 | Should Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
-			$ishObject.doclanguage_lng_element.StartsWith('VLANGUAGE') | Should Be $true 
+			$ishObject.fstatus.Length -ge 1 | Should -Be $true 
+			$ishObject.fstatus_lng_element.StartsWith('VSTATUS') | Should -Be $true 
+			$ishObject.doclanguage.Length -ge 1 | Should -Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
+			$ishObject.doclanguage_lng_element.StartsWith('VLANGUAGE') | Should -Be $true 
 		}
 	}
-
 	Context "Set-IshDocumentObj ParameterGroupMetadata" {
 		It "Mandatory parameter: LogicalId" {
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value "updated title"
 			{Set-IshDocumentObj -IshSession $ishSession `
 								-Version "1" `
 								-Lng "en" `
-								-Metadata $ishMetadataFieldsSet} | Should Throw
+								-Metadata $ishMetadataFieldsSet} | Should -Throw
 		}
 		It "Mandatory parameter: Version" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
@@ -128,7 +128,7 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			{Set-IshDocumentObj -IshSession $ishSession `
 								-LogicalId $ishObjectToUpdate.IshRef `
 								-Lng "en" `
-								-Metadata $ishMetadataFieldsSet} | Should Throw
+								-Metadata $ishMetadataFieldsSet} | Should -Throw
 		}
 		It "Mandatory parameter: Lng" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
@@ -140,9 +140,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			{Set-IshDocumentObj -IshSession $ishSession `
 								-LogicalId $ishObjectToUpdate.IshRef `
 								-Version $ishObjectToUpdate.version_version_value `
-								-Metadata $ishMetadataFieldsSet} | Should Throw
+								-Metadata $ishMetadataFieldsSet} | Should -Throw
 		}
-
 		It "Topic - metadata update" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
 							    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -156,7 +155,7 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-Version $ishObjectToUpdate.version_version_value `
 											-Lng $ishObjectToUpdate.doclanguage `
 											-Metadata $ishMetadataFieldsSet
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
 		}
 		It "Topic - metadata update with RequiredCurrentMetadata accepted" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
@@ -173,9 +172,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-Lng $ishObjectToUpdate.doclanguage `
 											-Metadata $ishMetadataFieldsSet `
 											-RequiredCurrentMetadata $ishRequiredCurrentMetadata
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
 		}
-		
 		It "Topic - metadata update with RequiredCurrentMetadata rejected" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
 							    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -185,15 +183,17 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$updatedTitle = $ishObjectToUpdate.ftitle_logical_value + "...updated"
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value $updatedTitle
 			$ishRequiredCurrentMetadata = Set-IshRequiredCurrentMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased
-			{Set-IshDocumentObj -IshSession $ishSession `
+			$exception = { Set-IshDocumentObj -IshSession $ishSession `
 								-LogicalId $ishObjectToUpdate.IshRef `
 								-Version $ishObjectToUpdate.version_version_value `
 								-Lng $ishObjectToUpdate.doclanguage `
 								-Metadata $ishMetadataFieldsSet `
-								-RequiredCurrentMetadata $ishRequiredCurrentMetadata} | 
-			Should Throw "The supplied expected metadata"
+								-RequiredCurrentMetadata $ishRequiredCurrentMetadata } | Should -Throw -PassThru
+								 "The supplied expected metadata"
+			# 14.0.4 message is: [-106011] The supplied expected metadata value "Released" does not match the current database value "In progress" so we rolled back your operation. To make the operation work you should make sure your value matches the latest database value. [f:158 fe:FSTATUS ft:LOV] [106011;InvalidCurrentMetadata]
+			$exception -like "*106011*" | Should -Be $true 
+			$exception -like "*InvalidCurrentMetadata*" | Should -Be $true
 		}
-		
 		It "Image - metadata update without Resolution" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Image $timestamp" |
 							    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -216,9 +216,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-Version $ishObjectToUpdate.version_version_value `
 											-Lng $ishObjectToUpdate.doclanguage `
 											-Metadata $ishMetadataFieldsSet
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
 		}
-		
 		It "Image - metadata update with Resolution" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Image $timestamp" |
 							    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -242,9 +241,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-Lng $ishObjectToUpdate.doclanguage `
 											-Resolution $ishResolution `
 											-Metadata $ishMetadataFieldsSet
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
 		}
-		
 		It "Image - metadata update with non-matching Resolution" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Image $timestamp" |
 							    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -262,34 +260,37 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 
 			$updatedTitle = $ishObjectToUpdate.ftitle_logical_value + "...updated"
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value $updatedTitle
-			{Set-IshDocumentObj -IshSession $ishSession `
+			$exception = { Set-IshDocumentObj -IshSession $ishSession `
 								-LogicalId $ishObjectToUpdate.IshRef `
 								-Version $ishObjectToUpdate.version_version_value `
 								-Lng $ishObjectToUpdate.doclanguage `
 								-Resolution "VRESHIGH" `
-								-Metadata $ishMetadataFieldsSet} | 
-			Should Throw "does not exist"
+								-Metadata $ishMetadataFieldsSet } | Should -Throw -PassThru
+			# 14.0.4 message is: [-102] The object GUID-862BD02A-422D-4E42-8626-725A12CF6D3A=3=en=High does not exist. [co:"GUID-862BD02A-422D-4E42-8626-725A12CF6D3A=3=en=High"] [102;ObjectNotFound]
+			$exception -like "*102*" | Should -Be $true 
+			$exception -like "*ObjectNotFound*" | Should -Be $true
 		}
 	}
-
-	Context “Set-IshDocumentObj ParameterGroupFileContent" {
-		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Set All Parameters Topic $timestamp" |
-					        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-		    			    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-		$ishObjectToUpdate = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
-
+	Context "Set-IshDocumentObj ParameterGroupFileContent" {
+		BeforeAll {
+			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Set All Parameters Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+			$ishObjectToUpdate = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Version '1' -Lng $ishLng -Metadata $ishTopicMetadata -Edt "EDTXML" -FileContent $ditaTopicFileContent
+		}
 		It "Parameter EDT explicitly EDTJPEG" {
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value "Updated title"
-			{Set-IshDocumentObj -IshSession $ishSession `
+			$exception = { Set-IshDocumentObj -IshSession $ishSession `
 								 -LogicalId $ishObjectToUpdate.IshRef `
 								 -Version $ishObjectToUpdate.version_version_value `
 								 -Lng $ishObjectToUpdate.doclanguage `
 								 -Metadata $ishMetadataFieldsSet `
 								 -Edt "EDTJPEG" `
-								 -FileContent "INVALIDFILECONTENT"} |
-			Should Throw "FileContent parameter is only supported with EDT[EDTXML], not EDT[EDTJPEG]."
+								 -FileContent "INVALIDFILECONTENT" } | Should -Throw -PassThru 
+			# ISHRemote message is: FileContent parameter is only supported with EDT[EDTXML], not EDT[EDTJPEG].
+			$exception -like "*FileContent*" | Should -Be $true
+			$exception -like "*EDTXML*" | Should -Be $true
 		}
-
 		It "Parameter FileContent has invalid xml content" {
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value "Updated title"
 			{Set-IshDocumentObj -IshSession $ishSession `
@@ -298,9 +299,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 								 -Lng $ishObjectToUpdate.doclanguage `
 								 -Metadata $ishMetadataFieldsSet `
 								 -FileContent "INVALIDFILECONTENT"} | 
-			Should Throw "Data at the root level is invalid. Line 1, position 1."
+			Should -Throw "Data at the root level is invalid. Line 1, position 1."
 		}
-
 		It "Provide both FileContent and FilePath" {
 			$tempFilePath = (New-TemporaryFile).FullName
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value "Updated title"
@@ -311,9 +311,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 								 -Metadata $ishMetadataFieldsSet `
 								 -FileContent $ditaTopicFileContent `
 								 -FilePath $tempFilePath} | 
-			Should Throw "Parameter set cannot be resolved using the specified named parameters."
+			Should -Throw "Parameter set cannot be resolved using the specified named parameters."
 		}
-		
 		It "Topic - update blob only" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Set All Parameters Topic $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -338,9 +337,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-FileContent $updatedContent
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			[string]$ishObjectContent = Get-Content -Path $fileInfo		
-			$ishObjectContent -eq $updatedContent | Should Be $true
+			$ishObjectContent -eq $updatedContent | Should -Be $true
 		}
-
 		It "Topic - update blob and metadata" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Set All Parameters Topic $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -368,10 +366,9 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			[string]$ishObjectContent = Get-Content -Path $fileInfo		
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$ishObjectContent -eq $updatedContent | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$ishObjectContent -eq $updatedContent | Should -Be $true
 		}
-		
 		It "Topic - update (RequiredCurrentMetadata accepted)" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic update with RequiredCurrentMetadata accepted $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -401,10 +398,9 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			[string]$ishObjectContent = Get-Content -Path $fileInfo		
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$ishObjectContent -eq $updatedContent | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$ishObjectContent -eq $updatedContent | Should -Be $true
 		}	
-		
 		It "Topic - update (RequiredCurrentMetadata rejected)" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic update with RequiredCurrentMetadata rejected $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -424,16 +420,17 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$updatedContent = $ishObjectToUpdateContent.Replace("(optional)", "(optional-updated)")
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value $updatedTitle
 			$ishRequiredCurrentMetadata = Set-IshRequiredCurrentMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased
-			{Set-IshDocumentObj -IshSession $ishSession `
+			$exception = { Set-IshDocumentObj -IshSession $ishSession `
 								-LogicalId $ishObjectToUpdate.IshRef `
 								-Version $ishObjectToUpdate.version_version_value `
 								-Lng $ishObjectToUpdate.doclanguage `
 								-Metadata $ishMetadataFieldsSet `
 								-RequiredCurrentMetadata $ishRequiredCurrentMetadata `
-								-FileContent $updatedContent} | 
-			Should Throw "The supplied expected metadata"
+								-FileContent $updatedContent } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-106011] The supplied expected metadata value "Released" does not match the current database value "In progress" so we rolled back your operation. To make the operation work you should make sure your value matches the latest database value. [f:158 fe:FSTATUS ft:LOV] [106011;InvalidCurrentMetadata]
+			$exception -like "*106011*" | Should -Be $true 
+			$exception -like "*InvalidCurrentMetadata*" | Should -Be $true
 		}
-		
 		It "Map - update blob and metadata" {
 			$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Map update $timestamp" |
 						      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -461,11 +458,10 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			[string]$ishObjectContent = Get-Content -Path $fileInfo		
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$ishObjectContent -eq $updatedContent | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$ishObjectContent -eq $updatedContent | Should -Be $true
 
 		}
-
 		It "Lib - update blob and metadata" {
 			$ishLibMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Lib update $timestamp" |
 						      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -493,12 +489,11 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			[string]$ishObjectContent = Get-Content -Path $fileInfo		
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$ishObjectContent -eq $updatedContent | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$ishObjectContent -eq $updatedContent | Should -Be $true
 		}
 	}
-	
-	Context “Set-IshDocumentObj ParameterGroupFilePath" {
+	Context "Set-IshDocumentObj ParameterGroupFilePath" {
 		It "Image - update blob only (providing EDT)" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Mandatory parameters Image $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -523,9 +518,8 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-FilePath $tempFilePathImage200x200
 
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
-			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should Be $true
+			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should -Be $true
 		}
-
 		It "Image - update metadata and blob (providing EDT)" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Mandatory parameters Image $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -555,10 +549,9 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should -Be $true
 		}
-		
 		It "Image - update metadata and blob providing EDT, RequiredCurrentMetadata accepted" {
 			$ishImageMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Mandatory parameters Image with  RequiredCurrentMetadata $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -590,10 +583,9 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should -Be $true
 		}
-		
 		It "Topic - update metadata and blob, RequiredCurrentMetadata rejected" {
 			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic update with RequiredCurrentMetadata rejected $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -615,16 +607,17 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$updatedContent | Out-File -FilePath $tempFilePathUpdated -Force
 			$ishMetadataFieldsSet = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level "Logical" -Value $updatedTitle
 			$ishRequiredCurrentMetadata = Set-IshRequiredCurrentMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased
-			{Set-IshDocumentObj -IshSession $ishSession `
+			$exception = { Set-IshDocumentObj -IshSession $ishSession `
 								-LogicalId $ishObjectToUpdate.IshRef `
 								-Version $ishObjectToUpdate.version_version_value `
 								-Lng $ishObjectToUpdate.doclanguage `
 								-Metadata $ishMetadataFieldsSet `
 								-RequiredCurrentMetadata $ishRequiredCurrentMetadata `
-								-FilePath $tempFilePathUpdated} | 
-			Should Throw "The supplied expected metadata"
+								-FilePath $tempFilePathUpdated } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-106011] The supplied expected metadata value "Released" does not match the current database value "In progress" so we rolled back your operation. To make the operation work you should make sure your value matches the latest database value. [f:158 fe:FSTATUS ft:LOV] [106011;InvalidCurrentMetadata]
+			$exception -like "*106011*" | Should -Be $true 
+			$exception -like "*InvalidCurrentMetadata*" | Should -Be $true
 		}	
-		
 		It "Update Other like EDT-TEXT" {
 			$ishOtherMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Update Other like EDT-TEXT $timestamp" |
 						        Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
@@ -646,35 +639,36 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 											-FilePath $tempFilePath
 			$fileInfo = $ishObject | Get-IshDocumentObjData -IshSession $ishSession -FolderPath (Join-Path $tempFolder $cmdletName)
 			
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
-			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
+			$fileInfoToUpdate.Length -lt $fileInfo.Length | Should -Be $true
 		}
 	}
-
-	Context “Set-IshDocumentObj IshObjectsGroup" {
-		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-
-		It "Parameter/pipe IshObject is empty" {
-			{Set-IshDocumentObj -IshSession $ishSession -IshObject @()} | Should Not Throw
-			{@() | Set-IshDocumentObj -IshSession $ishSession} | Should Not Throw
+	Context "Set-IshDocumentObj IshObjectsGroup" {
+		BeforeAll {
+			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
 		}
-		
+		It "Parameter/pipe IshObject is empty" {
+			{Set-IshDocumentObj -IshSession $ishSession -IshObject @()} | Should -Not -Throw
+			{@() | Set-IshDocumentObj -IshSession $ishSession} | Should -Not -Throw
+		}
 		It "Parameter IshObject invalid" {
 			{ Set-IshDocumentObj -IshSession $ishSession -IshObject "INVALIDISHOBJECT" } | 
-			Should Throw "Cannot bind parameter 'IshObject'. Cannot convert the ""INVALIDISHOBJECT"" value of type ""System.String"" to type ""Trisoft.ISHRemote.Objects.Public.IshObject""."
+			Should -Throw "Cannot bind parameter 'IshObject'. Cannot convert the ""INVALIDISHOBJECT"" value of type ""System.String"" to type ""Trisoft.ISHRemote.Objects.Public.IshObject""."
 		}
-
 		It "Provide as parameter/pipe deleted object" {
 			$ishObjectToUpdate = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
 			Remove-IshDocumentObj -IshSession $ishSession -IshObject $ishObjectToUpdate -Force
-			{$ishObjectSet = Set-IshDocumentObj -IshSession $ishSession -IshObject $ishObjectToUpdate} | 
-			Should Throw "does not exist"
-			{$ishObjectSet = $ishObjectToUpdate | Set-IshDocumentObj -IshSession $ishSession } | 
-			Should Throw "does not exist"
+			$exception = { $ishObjectSet = Set-IshDocumentObj -IshSession $ishSession -IshObject $ishObjectToUpdate } | Should -Throw -PassThru
+			# 14.0.4 message is: [-102] The object GUID-862BD02A-422D-4E42-8626-725A12CF6D3A=3=en=High does not exist. [co:"GUID-862BD02A-422D-4E42-8626-725A12CF6D3A=3=en=High"] [102;ObjectNotFound]
+			$exception -like "*102*" | Should -Be $true 
+			$exception -like "*ObjectNotFound*" | Should -Be $true
+			$exception = { $ishObjectSet = $ishObjectToUpdate | Set-IshDocumentObj -IshSession $ishSession } | Should -Throw -PassThru
+			# 14.0.4 message is: [-102] The object GUID-862BD02A-422D-4E42-8626-725A12CF6D3A=3=en=High does not exist. [co:"GUID-862BD02A-422D-4E42-8626-725A12CF6D3A=3=en=High"] [102;ObjectNotFound]
+			$exception -like "*102*" | Should -Be $true 
+			$exception -like "*ObjectNotFound*" | Should -Be $true
 		}
-		
 		It "Set metadata, provide multiple objects to IshObject" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectA = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
@@ -688,13 +682,12 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$ishObjectAUpdated = $ishObjectA | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishObjectBUpdated = $ishObjectB | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 
-			$ishObjectArray.Count | Should Be 2
-			$ishObjectA.ed -eq $ishObjectAUpdated.ed | Should Be $true
-			$ishObjectB.ed -eq $ishObjectBUpdated.ed | Should Be $true
-			$ishObjectArray[0].ftitle_logical_value | Should Be $updatedTitle
-			$ishObjectArray[1].ftitle_logical_value | Should Be $updatedTitle
+			$ishObjectArray.Count | Should -Be 2
+			$ishObjectA.ed -eq $ishObjectAUpdated.ed | Should -Be $true
+			$ishObjectB.ed -eq $ishObjectBUpdated.ed | Should -Be $true
+			$ishObjectArray[0].ftitle_logical_value | Should -Be $updatedTitle
+			$ishObjectArray[1].ftitle_logical_value | Should -Be $updatedTitle
 		}
-		
 		It "Resubmit blob, provide multiple objects to IshObject" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectA = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
@@ -706,11 +699,10 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$ishObjectAUpdated = $ishObjectA | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishObjectBUpdated = $ishObjectB | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 
-			$ishObjectArray.Count | Should Be 2
-			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should Be $true
-			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should Be $true
+			$ishObjectArray.Count | Should -Be 2
+			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should -Be $true
+			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should -Be $true
 		}
-		
 		It "Resubmit blob, provide multiple objects via pipeline" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectA = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
@@ -723,11 +715,10 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$ishObjectAUpdated = $ishObjectA | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishObjectBUpdated = $ishObjectB | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 
-			$ishObjectArray.Count | Should Be 2
-			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should Be $true
-			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should Be $true
+			$ishObjectArray.Count | Should -Be 2
+			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should -Be $true
+			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should -Be $true
 		}
-
 		It "Resubmit blob, provide multiple objects via pipeline with RequiredCurrentMetadata accepted" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectA = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
@@ -741,11 +732,10 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$ishObjectAUpdated = $ishObjectA | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishObjectBUpdated = $ishObjectB | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 
-			$ishObjectArray.Count | Should Be 2
-			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should Be $true
-			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should Be $true
+			$ishObjectArray.Count | Should -Be 2
+			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should -Be $true
+			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should -Be $true
 		}
-		
 		It "Resubmit blob, provide multiple objects via pipeline with RequiredCurrentMetadata rejected" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectA = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
@@ -753,10 +743,11 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$ishObjectAB = @($ishObjectA, $ishObjectB) | Get-IshDocumentObj -IshSession $ishSession -IncludeData
 			
 			$ishRequiredCurrentMetadata = Set-IshRequiredCurrentMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased
-			{$ishObjectAB | Set-IshDocumentObj -IshSession $ishSession -RequiredCurrentMetadata $ishRequiredCurrentMetadata} | 
-			Should Throw "The supplied expected metadata"
+			$exception = { $ishObjectAB | Set-IshDocumentObj -IshSession $ishSession -RequiredCurrentMetadata $ishRequiredCurrentMetadata } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-106011] The supplied expected metadata value "Released" does not match the current database value "In progress" so we rolled back your operation. To make the operation work you should make sure your value matches the latest database value. [f:158 fe:FSTATUS ft:LOV] [106011;InvalidCurrentMetadata]
+			$exception -like "*106011*" | Should -Be $true 
+			$exception -like "*InvalidCurrentMetadata*" | Should -Be $true
 		}
-		
 		It "Resubmit blob and set Metadata, provide multiple objects via pipeline" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectA = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent | 
@@ -771,13 +762,12 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 			$ishObjectAUpdated = $ishObjectA | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishObjectBUpdated = $ishObjectB | Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 
-			$ishObjectArray.Count | Should Be 2
-			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should Be $true
-			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should Be $true
-			$ishObjectArray[0].ftitle_logical_value | Should Be $updatedTitle
-			$ishObjectArray[1].ftitle_logical_value | Should Be $updatedTitle
+			$ishObjectArray.Count | Should -Be 2
+			$ishObjectA.ed -ne $ishObjectAUpdated.ed | Should -Be $true
+			$ishObjectB.ed -ne $ishObjectBUpdated.ed | Should -Be $true
+			$ishObjectArray[0].ftitle_logical_value | Should -Be $updatedTitle
+			$ishObjectArray[1].ftitle_logical_value | Should -Be $updatedTitle
 		}
-
 		It "Resubmit blob and set Metadata, provide single object via pipeline" {
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "ED" -Level Lng
 			$ishObjectToUpdate = Add-IshDocumentObj -IshSession $ishSession `
@@ -794,17 +784,17 @@ Describe “Set-IshDocumentObj" -Tags "Create" {
 						 Set-IshDocumentObj -IshSession $ishSession -Metadata $ishMetadataFieldsSet |
 						 Get-IshDocumentObj -IshSession $ishSession -RequestedMetadata $requestedMetadata
 
-			$ishObjectToUpdate.ed -ne $ishObject.ed | Should Be $true
-			$ishObject.ftitle_logical_value | Should Be $updatedTitle
+			$ishObjectToUpdate.ed -ne $ishObject.ed | Should -Be $true
+			$ishObject.ftitle_logical_value | Should -Be $updatedTitle
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 	try { Remove-Item $tempFilePath -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/EventMonitor/GetIshEvent.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/EventMonitor/GetIshEvent.Tests.ps1
@@ -1,117 +1,119 @@
-Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshEvent"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshEvent"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshEvent" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
-						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	# Forcing a status transition to release, triggers Translation Management which means a BackgroundTask and EventMonitor entry
-	$ishObject = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
-				 Set-IshDocumentObj -IshSession $ishSession -Metadata (Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased)
+Describe "Get-IshEvent" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-
-    $allProgressMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PROGRESSID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CREATIONDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MODIFICATIONDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTTYPE | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name DESCRIPTION |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PARENTPROGRESSID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MAXIMUMPROGRESS |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CURRENTPROGRESS
-    $allDetailMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DETAILID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROGRESSID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name CREATIONDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name HOSTNAME |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name ACTION | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DESCRIPTION |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROCESSID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name THREADID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATATYPE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATASIZE
-    $allMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PROGRESSID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CREATIONDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MODIFICATIONDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTTYPE | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name DESCRIPTION |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PARENTPROGRESSID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MAXIMUMPROGRESS |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CURRENTPROGRESS |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DETAILID | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROGRESSID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name CREATIONDATE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name HOSTNAME |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name ACTION | 
-			           Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DESCRIPTION |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Value |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Element |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROCESSID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name THREADID |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATATYPE |
-					   Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATASIZE
-
-
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+							Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		# Forcing a status transition to release, triggers Translation Management which means a BackgroundTask and EventMonitor entry
+		$ishObject = Add-IshDocumentObj -IshSession $ishSession -FolderId $ishFolderTopic.IshFolderRef -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent |
+					Set-IshDocumentObj -IshSession $ishSession -Metadata (Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusReleased)
+		$allProgressMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PROGRESSID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CREATIONDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MODIFICATIONDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTTYPE | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name DESCRIPTION |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PARENTPROGRESSID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MAXIMUMPROGRESS |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CURRENTPROGRESS
+		$allDetailMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DETAILID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROGRESSID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name CREATIONDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name HOSTNAME |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name ACTION | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DESCRIPTION |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROCESSID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name THREADID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATATYPE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATASIZE
+		$allMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PROGRESSID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CREATIONDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MODIFICATIONDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTTYPE | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name DESCRIPTION |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PARENTPROGRESSID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name MAXIMUMPROGRESS |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name CURRENTPROGRESS |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DETAILID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROGRESSID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name CREATIONDATE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name HOSTNAME |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name ACTION | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name DESCRIPTION |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name STATUS -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Value |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTLEVEL -ValueType Element |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name PROCESSID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name THREADID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATATYPE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Detail -Name EVENTDATASIZE
+	}
 	Context "Get-IshEvent" {
-		$metadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PROGRESSID | 
-		            Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTID |
-					Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTTYPE |
-					Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS
-		$ishEvent = (Get-IshEvent -IshSession $ishSession -UserFilter All -RequestedMetadata $metadata)[0]
+		BeforeAll {
+			$metadata = Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name PROGRESSID | 
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTID |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name EVENTTYPE |
+						Set-IshRequestedMetadataField -IshSession $ishSession -Level Progress -Name STATUS
+			$ishEvent = (Get-IshEvent -IshSession $ishSession -UserFilter All -RequestedMetadata $metadata)[0]
+		}
 		It "GetType().Name" {
-			$ishEvent.GetType().Name | Should BeExactly "IshEvent"
+			$ishEvent.GetType().Name | Should -BeExactly "IshEvent"
 		}
 		It "ishObject.IshField" {
-			$ishEvent.IshField | Should Not BeNullOrEmpty
+			$ishEvent.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObject.IshRef" {
-			$ishEvent.IshRef | Should Not BeNullOrEmpty
+			$ishEvent.IshRef | Should -Not -BeNullOrEmpty
 		}
 		# Double check following 2 ReferenceType enum usage 
 		It "ishEvent.ProgressRef" {
-			$ishEvent.ProgressRef | Should Not BeNullOrEmpty
+			$ishEvent.ProgressRef | Should -Not -BeNullOrEmpty
 		}
 		#It "ishEvent.DetailRef" {  # Requires BackgroundTask to be running to get detail entries
-		#	$ishEvent.DetailRef | Should Not BeNullOrEmpty
+		#	$ishEvent.DetailRef | Should -Not -BeNullOrEmpty
 		#}
 		It "ishEvent ConvertTo-Json" {
-			(ConvertTo-Json $ishEvent).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishEvent).Length -gt 2 | Should -Be $true
 		}
 		It "Parameter IshSession/ModifiedSince/UserFilter invalid" {
-			{ Get-IshEvent -IShSession "INVALIDISHSESSION" -ModifiedSince "INVALIDDATE" -UserFilter "INVALIDUSERFILTER" } | Should Throw
+			{ Get-IshEvent -IShSession "INVALIDISHSESSION" -ModifiedSince "INVALIDDATE" -UserFilter "INVALIDUSERFILTER" } | Should -Throw
 		}
 		It "Parameter RequestedMetadata/MetadataFile invalid" {
-			{ Get-IshEvent -IShSession $ishSession -RequestedMetadata "INVALIDMETADATA" -MetadataFilter "INVALIDFILTER"  } | Should Throw
+			{ Get-IshEvent -IShSession $ishSession -RequestedMetadata "INVALIDMETADATA" -MetadataFilter "INVALIDFILTER"  } | Should -Throw
 		}
 		It "Parameter RequestedMetadata only Progress level on unstarted event" {
 			$eventPrefix = $cmdletName
@@ -122,61 +124,61 @@ Describe “Get-IshEvent" -Tags "Create" {
 			$event = $ishSession.EventMonitor25.StartEvent($startEventRequest)
 			$metadataFilter = Set-IshMetadataFilterField -Name "EVENTID" -Level "Progress" -FilterOperator "Equal" -Value $event.eventId
 			$ishEvent = Get-IshEvent -IshSession $ishSession -EventTypes @($startEventRequest.eventType) -RequestedMetadata $allProgressMetadata -MetadataFilter $metaDataFilter
-			$ishEvent.Count | Should Be 1
+			$ishEvent.Count | Should -Be 1
 		}
 		It "Parameter IshSession/UserFilter/MetadataFilter are optional" {
 			$ishEvent = (Get-IshEvent -ModifiedSince ((Get-Date).AddSeconds(-10)) -RequestedMetadata $allProgressMetadata)[0]
-			($ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name EVENTID -ValueType Value).Length -gt 0 | Should Be $true
-			#($ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Element).StartsWith('VUSER') | Should Be $false  # unexpected but ValueType Element is not returned by the API call
+			($ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name EVENTID -ValueType Value).Length -gt 0 | Should -Be $true
+			#($ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name USERID -ValueType Element).StartsWith('VUSER') | Should -Be $false  # unexpected but ValueType Element is not returned by the API call
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "Descriptive"
 			$ishEvent = (Get-IshEvent -IShSession $ishSession)[0]
-			$ishEvent.IshField.Count | Should Be 2
+			$ishEvent.IshField.Count | Should -Be 2
 			$ishSession.DefaultRequestedMetadata = "Basic"
 			$ishEvent = (Get-IshEvent -IShSession $ishSession)[0]
-			$ishEvent.status.Length -gt 0 | Should Be $true
-			$ishEvent.IshField.Count | Should Be 9
+			$ishEvent.status.Length -gt 0 | Should -Be $true
+			$ishEvent.IshField.Count | Should -Be 9
 			$ishSession.DefaultRequestedMetadata = "All"
 			$ishEvent = (Get-IshEvent -IShSession $ishSession)[0]
-			$ishEvent.IshField.Count | Should Be 10
+			$ishEvent.IshField.Count | Should -Be 10
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
 		}
 		It "Parameter ModifiedSince is now" {
-			(Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(1)) -UserFilter All).Count | Should Be 0
+			(Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(1)) -UserFilter All).Count | Should -Be 0
 		}
 		It "Parameter RequestedMetadata only all of Progress level" {
 			$ishEvent = (Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddSeconds(-10)) -UserFilter All -RequestedMetadata $allProgressMetadata)[0]
-			$ishEvent.ProgressRef -gt 0 | Should Be $true
-			#$ishEvent.DetailRef -gt 0 | Should Be $true
-			$ishEvent.IshField.Count | Should Be 10
+			$ishEvent.ProgressRef -gt 0 | Should -Be $true
+			#$ishEvent.DetailRef -gt 0 | Should -Be $true
+			$ishEvent.IshField.Count | Should -Be 10
 		}
 		It "Parameter RequestedMetadata only all of Detail level" {
 			$ishEvent = (Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter All -RequestedMetadata $allDetailMetadata)[0]
-			$ishEvent.ProgressRef -gt 0 | Should Be $true
-			$ishEvent.DetailRef -gt 0 | Should Be $true
-			$ishEvent.IshField.Count -ge 20 | Should Be $true  # Perhaps expected 10 Progress level fields, but Get-IshEvent currently always retrieves details as well
+			$ishEvent.ProgressRef -gt 0 | Should -Be $true
+			$ishEvent.DetailRef -gt 0 | Should -Be $true
+			$ishEvent.IshField.Count -ge 20 | Should -Be $true  # Perhaps expected 10 Progress level fields, but Get-IshEvent currently always retrieves details as well
 		}
 		It "Parameter RequestedMetadata PipelineObjectPreference=PSObjectNoteProperty" {
-			$ishSession.PipelineObjectPreference | Should Be "PSObjectNoteProperty"
+			$ishSession.PipelineObjectPreference | Should -Be "PSObjectNoteProperty"
 			$ishEvent = (Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter All -RequestedMetadata $allMetadata)[0]
-			$ishEvent.GetType().Name | Should BeExactly "IshEvent"  # and not PSObject
-			[bool]($ishEvent.PSobject.Properties.name -match "status") | Should Be $true
-			[bool]($ishEvent.PSobject.Properties.name -match "userid") | Should Be $true
-			[bool]($ishEvent.PSobject.Properties.name -match "modificationdate") | Should Be $true
-			[bool]($ishEvent.PSobject.Properties.name -match "status_detail_value") | Should Be $true
-			$ishEvent.modificationdate -like "*/*" | Should Be $false  # It should be sortable date format: yyyy-MM-ddTHH:mm:ss
+			$ishEvent.GetType().Name | Should -BeExactly "IshEvent"  # and not PSObject
+			[bool]($ishEvent.PSobject.Properties.name -match "status") | Should -Be $true
+			[bool]($ishEvent.PSobject.Properties.name -match "userid") | Should -Be $true
+			[bool]($ishEvent.PSobject.Properties.name -match "modificationdate") | Should -Be $true
+			[bool]($ishEvent.PSobject.Properties.name -match "status_detail_value") | Should -Be $true
+			$ishEvent.modificationdate -like "*/*" | Should -Be $false  # It should be sortable date format: yyyy-MM-ddTHH:mm:ss
 		}
 		It "Parameter RequestedMetadata PipelineObjectPreference=Off" {
 		    $pipelineObjectPreference = $ishSession.PipelineObjectPreference
 			$ishSession.PipelineObjectPreference = "Off"
 			$ishEvent = (Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter All -RequestedMetadata $allMetadata)[0]
-			$ishEvent.GetType().Name | Should BeExactly "IshEvent"
-			[bool]($ishEvent.PSobject.Properties.name -match "status") | Should Be $false
-			[bool]($ishEvent.PSobject.Properties.name -match "userid") | Should Be $false
-			[bool]($ishEvent.PSobject.Properties.name -match "modificationdate") | Should Be $false
-			[bool]($ishEvent.PSobject.Properties.name -match "status_detail_value") | Should Be $false
+			$ishEvent.GetType().Name | Should -BeExactly "IshEvent"
+			[bool]($ishEvent.PSobject.Properties.name -match "status") | Should -Be $false
+			[bool]($ishEvent.PSobject.Properties.name -match "userid") | Should -Be $false
+			[bool]($ishEvent.PSobject.Properties.name -match "modificationdate") | Should -Be $false
+			[bool]($ishEvent.PSobject.Properties.name -match "status_detail_value") | Should -Be $false
 			$ishSession.PipelineObjectPreference = $pipelineObjectPreference
 		}
 		It "Parameter MetadataFilter" {
@@ -185,39 +187,39 @@ Describe “Get-IshEvent" -Tags "Create" {
 			                # | Set-IshMetadataFilterField -IshSession $ishSession -Level Progress -Name USERID -Value ($ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name USERID)  # Seems just like higher that USERID by valuetype retrieval and filtering are not working
 			$ishEventArray = Get-IshEvent -IshSession $ishSession -MetadataFilter $filterMetadata
 			#Write-Host ("ishEvent.IshRef["+ $ishEvent.IshRef + "] ishEventArray.IshRef["+ $ishEvent.IshRef + "]")
-			$ishEventArray.Count -ge 1 | Should Be $true
+			$ishEventArray.Count -ge 1 | Should -Be $true
 		}
 		It "Parameter IshEvent invalid" {
-			{ Get-IshEvent -IshSession $ishSession -IshEvent "INVALIDISHEVENT" } | Should Throw
+			{ Get-IshEvent -IshSession $ishSession -IshEvent "INVALIDISHEVENT" } | Should -Throw
 		}
 		It "Parameter IshEvent Single" {
 			$ishEvent = (Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter Current)[0]
 			$eventId = $ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name EVENTID
 			$ishEventArray = Get-IshEvent -IshSession $ishSession -IshEvent $ishEvent
-			$ishEventArray.Count -ge 1 | Should Be $true
-			$ishEventArray.IshRef | Should Be $eventId
+			$ishEventArray.Count -ge 1 | Should -Be $true
+			$ishEventArray.IshRef | Should -Be $eventId
 		}
-		<# TODO It "Parameter IshEvent Multiple" {
+		<# TODO [Could] It "Parameter IshEvent Multiple" {
 		}
 		#>
 		It "Pipeline IshEvent Single" {
 			$ishEvent = (Get-IshEvent -IshSession $ishSession -ModifiedSince ((Get-Date).AddMinutes(-1)) -UserFilter Current)[0]
 			$eventId = $ishEvent | Get-IshMetadataField -IshSession $ishSession -Level Progress -Name EVENTID
 			$ishEventArray = $ishEvent | Get-IshEvent -IshSession $ishSession
-			$ishEventArray.Count -ge 1 | Should Be $true
-			$ishEventArray.IshRef | Should Be $eventId
+			$ishEventArray.Count -ge 1 | Should -Be $true
+			$ishEventArray.IshRef | Should -Be $eventId
 		}
-		<# TODO It "Pipeline IshEvent Multiple" {
+		<# TODO [Could] It "Pipeline IshEvent Multiple" {
 		}
 		#>
 	}
 	#>
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/GetIshMetadataField.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/GetIshMetadataField.Tests.ps1
@@ -1,120 +1,117 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshMetadataField"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshMetadataField"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshMetadataField" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-						 Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element
-	$ishFolderDataOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder Data -RequestedMetadata $requestedMetadata
-	$ishFolderSystemOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder System -RequestedMetadata $requestedMetadata
-	$ishFolderFavoritesOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites -RequestedMetadata $requestedMetadata
-	$ishFolderEditorTemplateOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -RequestedMetadata $requestedMetadata
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
+Describe "Get-IshMetadataField" -Tags "Read" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element
+		$ishFolderDataOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder Data -RequestedMetadata $requestedMetadata
+		$ishFolderSystemOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder System -RequestedMetadata $requestedMetadata
+		$ishFolderFavoritesOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites -RequestedMetadata $requestedMetadata
+		$ishFolderEditorTemplateOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -RequestedMetadata $requestedMetadata
+	}
 	Context "Get-IshMetadataField -IshSession ishSession returns String object" {
-		$ishFolderData = Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshField $ishFolderDataOriginal.IshField
 		It "GetType().Name" {
-			$ishFolderData.GetType().Name | Should BeExactly "String"
+			$ishFolderData = Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshField $ishFolderDataOriginal.IshField
+			$ishFolderData.GetType().Name | Should -BeExactly "String"
 		}
 	}
-
-	Context “Get-IshMetadataField -IshSession ishSession IshFieldsGroup" {
+	Context "Get-IshMetadataField -IshSession ishSession IshFieldsGroup" {
 		It "Parameter IshSession/Name invalid" {
-			{ Get-IshMetadataField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" } | Should Throw
+			{ Get-IshMetadataField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" } | Should -Throw
 		}
 		It "Parameter Name invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" } | Should -Throw
 		}
 		It "Parameter Level invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should -Throw
 		}
 		It "Parameter ValueType invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should -Throw
 		}
 		It "Parameter IshFolder FNAME" {
-			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshField $ishFolderSystemOriginal.IshField | Should Not BeNullOrEmpty
+			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshField $ishFolderSystemOriginal.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter IshFolder FDOCUMENTTYPE" {
-			Get-IshMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" -Level None -IshField $ishFolderSystemOriginal.IshField | Should Be "None"
+			Get-IshMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" -Level None -IshField $ishFolderSystemOriginal.IshField | Should -Be "None"
 		}
 		It "Parameter IshFolder READ-ACCESS with implicit IshSession" {
-			Get-IshMetadataField -Name "READ-ACCESS" -Level None -IshField $ishFolderSystemOriginal.IshField -ValueType Element | Should BeNullOrEmpty
+			Get-IshMetadataField -Name "READ-ACCESS" -Level None -IshField $ishFolderSystemOriginal.IshField -ValueType Element | Should -BeNullOrEmpty
 		}
 	}
-
 	Context "Get-IshMetadataField -IshSession ishSession IshObjectGroup" {
 		It "Parameter IshObject invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshObject "INVALIDOBJECT" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshObject "INVALIDOBJECT" } | Should -Throw
 		}
 		It "Parameter IshObject Single" {
 			$ishUser = Get-IshUser -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "USERNAME")
-			(Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshObject $ishUser).Count | Should Be 1
+			(Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshObject $ishUser).Count | Should -Be 1
 		}
 	}
-
 	Context "Get-IshMetadataField -IshSession ishSession IshFolderGroup" {
 		It "Parameter IshFolder invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder "INVALIDFOLDER" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder "INVALIDFOLDER" } | Should -Throw
 		}
 		It "Parameter IshFolder Single" {
-			(Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder $ishFolderDataOriginal).Count | Should Be 1
+			(Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder $ishFolderDataOriginal).Count | Should -Be 1
 		}
 		It "Parameter IshFolder Multiple" {
-			(Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder @($ishFolderDataOriginal,$ishFolderFavoritesOriginal)).Count | Should Be 2
+			(Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder @($ishFolderDataOriginal,$ishFolderFavoritesOriginal)).Count | Should -Be 2
 		}
 		It "Pipeline IshFolder" {
-			(@($ishFolderDataOriginal) | Get-IshMetadataField -IshSession $ishSession -Name "FNAME").Count | Should Be 1
+			(@($ishFolderDataOriginal) | Get-IshMetadataField -IshSession $ishSession -Name "FNAME").Count | Should -Be 1
 		}
 		It "Pipeline IshFolder Multiple" {
-			(@($ishFolderDataOriginal,$ishFolderFavoritesOriginal) | Get-IshMetadataField -IshSession $ishSession -Name "FNAME").Count | Should Be 2
+			(@($ishFolderDataOriginal,$ishFolderFavoritesOriginal) | Get-IshMetadataField -IshSession $ishSession -Name "FNAME").Count | Should -Be 2
 		}
 	}
-	
 	Context "Get-IshMetadataField -IshSession ishSession IshEventGroup" {
 		It "Parameter IshEvent invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshEvent "INVALIDEVENT" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshEvent "INVALIDEVENT" } | Should -Throw
 		}
 		It "Pipeline IshEvent Multiple" {
 			#TODO test possibly is slow (or fails) when there are no EventMonitor entries
-			(Get-IshEvent -IshSession $ishSession -ModifiedSince (Get-Date).AddMonths(-3) | Get-IshMetadataField -IshSession $ishSession -Name "EVENTTYPE" -Level Progress).Count -ge 0 | Should Be $true
+			(Get-IshEvent -IshSession $ishSession -ModifiedSince (Get-Date).AddMonths(-3) | Get-IshMetadataField -IshSession $ishSession -Name "EVENTTYPE" -Level Progress).Count -ge 0 | Should -Be $true
 		}
 	}
-
 	Context "Get-IshMetadataField -IshSession ishSession IshBackgroundTask" {
 		It "Parameter IshBackgroundTask invalid" {
-			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshBackgroundTask "INVALIDBACKGROUNDTASK" } | Should Throw
+			{ Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshBackgroundTask "INVALIDBACKGROUNDTASK" } | Should -Throw
 		}
 		It "Pipeline IshBackgroundTask Multiple" {
 			#TODO test possibly is slow (or fails) when there are no EventMonitor entries
-			(Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince (Get-Date).AddMonths(-3) | Get-IshMetadataField -IshSession $ishSession -Name "EVENTTYPE" -Level Task).Count -ge 0 | Should Be $true
+			(Get-IshBackgroundTask -IshSession $ishSession -ModifiedSince (Get-Date).AddMonths(-3) | Get-IshMetadataField -IshSession $ishSession -Name "EVENTTYPE" -Level Task).Count -ge 0 | Should -Be $true
 		}
 	}
 	Context "Get-IshMetadataField IshFields.ToXml() for API Testing" {
 		It "Trisoft.ISHRemote.Objects.IShFields is public" {
-			{ New-Object -TypeName Trisoft.ISHRemote.Objects.IShFields } | Should Not Throw
+			{ New-Object -TypeName Trisoft.ISHRemote.Objects.IShFields } | Should -Not -Throw
 		}
 		It "Trisoft.ISHRemote.Objects.IShFields.AddField() is public" {
-			{ (New-Object -TypeName Trisoft.ISHRemote.Objects.IShFields).AddField((Set-IshRequestedMetadataField -IshSession $ishSession -Name "USERNAME")).ToXml() } | Should Not Throw
+			{ (New-Object -TypeName Trisoft.ISHRemote.Objects.IShFields).AddField((Set-IshRequestedMetadataField -IshSession $ishSession -Name "USERNAME")).ToXml() } | Should -Not -Throw
 		}
 		It "Trisoft.ISHRemote.Objects.IShFields.ToXml() xml content single" {
 			$ishFields = New-Object -TypeName Trisoft.ISHRemote.Objects.IShFields
 			$ishFields.AddField((Set-IshRequestedMetadataField -IshSession $ishSession -Name "USERNAME"))
 			$result = '<?xml version="1.0" encoding="utf-16"?><ishfields><ishfield name="USERNAME" level="none" ishvaluetype="value" /></ishfields>'
-			$ishFields.ToXML() -eq $result | Should Be $true
+			$ishFields.ToXML() -eq $result | Should -Be $true
 		}
 		It "Trisoft.ISHRemote.Objects.IShFields.ToXml() xml content multiple" {
 			$ishFields = New-Object -TypeName Trisoft.ISHRemote.Objects.IShFields
 			$ishFields.AddField((Set-IshRequestedMetadataField -IshSession $ishSession -Name "USERNAME"))
 			$ishFields.AddField((Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP"))
 			$result = '<?xml version="1.0" encoding="utf-16"?><ishfields><ishfield name="USERNAME" level="none" ishvaluetype="value" /><ishfield name="FUSERGROUP" level="none" ishvaluetype="value" /></ishfields>'
-			$ishFields.ToXML() -eq $result | Should Be $true
+			$ishFields.ToXML() -eq $result | Should -Be $true
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/SetIshMetadataField.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/SetIshMetadataField.Tests.ps1
@@ -1,99 +1,100 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Set-IshMetadataField"
-try {
+BeforeAll {
+	$cmdletName = "Set-IshMetadataField"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Set-IshMetadataField" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-						 Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element
-	$ishFolderDataOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder Data -RequestedMetadata $requestedMetadata
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
+Describe "Set-IshMetadataField" -Tags "Read" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element
+		$ishFolderDataOriginal = Get-IshFolder -IShSession $ishSession -BaseFolder Data -RequestedMetadata $requestedMetadata
+	}
 	Context "Set-IshMetadataField returns IshMetadataField" {
 		It "GetType().Name" {
-			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE").GetType().Name | Should BeExactly "IshMetadataField"
+			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE").GetType().Name | Should -BeExactly "IshMetadataField"
 		}
 		It "Parameter IshSession/Name/Level invalid" {
-			{ Set-IshMetadataField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should Throw
+			{ Set-IshMetadataField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should -Throw
 		}
 		It "Parameter ValueType invalid" {
-			{ Set-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should Throw
+			{ Set-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should -Throw
 		}
 		It "Parameter Name" {
-			Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" | Should Be ""
+			Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" | Should -Be ""
 		}
 		It "Parameter Name Level" {
-			Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Should Be ""
+			Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Should -Be ""
 		}
 		It "Parameter Name Level Value" {
 			$value = "MyString"
-			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical) -eq $value | Should Be $true
+			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical) -eq $value | Should -Be $true
 		}
 		It "Parameter Name Level ValueType Value" {
 			$value = "MYSTRING"
-			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 		It "Parameter Name Level ValueType Value Overwrite" {
 			$value = "MYSTRING"
 			(Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value "ValueThatWillBeOverwritten" | 
-			 Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should Be 1
+			 Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should -Be 1
 		}
 		It "Parameter IshFields Single Add" {
 			$ishFields = $null
 			$value = "SingleString"
-			(Set-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			(Set-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 		It "Parameter IshFields Single Update" {
 			$value = "OrginalString"
 			$ishFields = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$value = "NewString"
-			(Set-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			(Set-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 		It "Parameter IshField Multiple duplicate entries will be removed" {
 			$value = "OrginalString"
 			$ishFieldA =Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$ishFieldB =Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$value = "SingleString"
-			(Set-IshMetadataField -IshSession $ishSession -IshField @($ishFieldA,$ishFieldB) -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should Be 1
+			(Set-IshMetadataField -IshSession $ishSession -IshField @($ishFieldA,$ishFieldB) -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should -Be 1
 		}
 		It "Pipeline IshFields Single with implicit IshSession" {
 			$value = "OrginalString"
 			$ishFieldA =Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$value = "SingleString"
-			($ishFieldA | Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			($ishFieldA | Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 		It "Pipeline IshFields Multiple with implicit IshSession" {
 			$value = "OrginalString"
 			$ishFieldA =Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$ishFieldB =Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$value = "SingleString"
-			(@($ishFieldA,$ishFieldB) | Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should Be 1
+			(@($ishFieldA,$ishFieldB) | Set-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should -Be 1
 		}
 	}
-
 	Context "Set-IshMetadataField returns IshFolder" {
 		It "GetType().Name" {
-			(Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder $ishFolderDataOriginal).GetType().Name | Should BeExactly "IshFolder"
+			(Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -IshFolder $ishFolderDataOriginal).GetType().Name | Should -BeExactly "IshFolder"
 		}
 		It "Parameter Name Level ValueType Value" {
 			$value = "MYSTRING"
 			($ishFolderDataOriginal |
 			 Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -ValueType Element -value $value |
-			 Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -ValueType Element) -eq $value | Should Be $true
+			 Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -ValueType Element) -eq $value | Should -Be $true
 		}
 	}
-
-	Context “Alias Set-IshRequiredCurrentMetadataField" {
+	Context "Alias Set-IshRequiredCurrentMetadataField" {
 		It "Parameter IshFields Single" {
 			$ishFields = $null
 			$value = "SingleString"
-			(Set-IshRequiredCurrentMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			(Set-IshRequiredCurrentMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/SetIshMetadataFilterField.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/SetIshMetadataFilterField.Tests.ps1
@@ -1,85 +1,88 @@
-ï»¿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Set-IshMetadataFilterField"
-try {
+BeforeAll {
+	$cmdletName = "Set-IshMetadataFilterField"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe â€œSet-IshMetadataFilterField" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe “Set-IshMetadataFilterField" -Tags "Read" {
 
 	Context "Set-IshMetadataFilterField -IshSession $ishSession returns IshMetadataFilterField" {
 		It "GetType().Name" {
-			(Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE").GetType().Name | Should BeExactly "IshMetadataFilterField"
+			(Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE").GetType().Name | Should -BeExactly "IshMetadataFilterField"
 		}
 	}
 
-	Context â€œSet-IshMetadataFilterField" {
+	Context “Set-IshMetadataFilterField" {
 		It "Parameter IshSession/Name/Level invalid" {
-			{ Set-IshMetadataFilterField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should Throw
+			{ Set-IshMetadataFilterField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should -Throw
 		}
 		It "Parameter ValueType invalid" {
-			{ Set-IshMetadataFilterField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should Throw
+			{ Set-IshMetadataFilterField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should -Throw
 		}
 		It "Parameter Name" {
-			Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" | Should Be ""
+			Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" | Should -Be ""
 		}
 		It "Parameter Name Level" {
-			Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Should Be ""
+			Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Should -Be ""
 		}
 		It "Parameter Name Level Operator" {
-			Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -FilterOperator Equal | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Should Be ""
+			Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -FilterOperator Equal | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical | Should -Be ""
 		}
 		It "Parameter Name Level Operator Value" {
 			$value = "MyString"
-			(Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -FilterOperator Equal -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical) -eq $value | Should Be $true
+			(Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -FilterOperator Equal -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical) -eq $value | Should -Be $true
 		}
 		It "Parameter Name Level Operator Value Twice" {
 			(Set-IshMetadataFilterField -IshSession $ishSession -Name 'FISHLASTMODIFIEDON' -Level Lng -FilterOperator GreaterThanOrEqual -Value '01/01/2016' |
-			Set-IshMetadataFilterField -IshSession $ishSession -Name 'FISHLASTMODIFIEDON' -Level Lng -FilterOperator LessThan -Value '02/01/2016').Length | Should Be 2
+			Set-IshMetadataFilterField -IshSession $ishSession -Name 'FISHLASTMODIFIEDON' -Level Lng -FilterOperator LessThan -Value '02/01/2016').Length | Should -Be 2
 		}
 		It "Parameter Name Level Operator ValueType Value" {
 			$value = "VUSERADMIN"
-			(Set-IshMetadataFilterField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -FilterOperator Equal -ValueType Element -value $value).FilterOperator -match 'equal' | Should Be $true
+			(Set-IshMetadataFilterField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -FilterOperator Equal -ValueType Element -value $value).FilterOperator -match 'equal' | Should -Be $true
 		}
 		It "Parameter Name Level Operator ValueType Value Twice" {
 			$value = "VUSERADMIN"
 			(Set-IshMetadataFilterField -IshSession $ishSession -Name 'FAUTHOR' -Level Lng -FilterOperator In -ValueType Element -Value $value |
-			Set-IshMetadataFilterField -IshSession $ishSession -Name 'FAUTHOR' -Level Lng -FilterOperator Equal -ValueType Element -Value $value).Length | Should Be 2
+			Set-IshMetadataFilterField -IshSession $ishSession -Name 'FAUTHOR' -Level Lng -FilterOperator Equal -ValueType Element -Value $value).Length | Should -Be 2
 		}
 		It "Parameter IshFields Single Add" {
 			$ishFields = $null
 			$value = "SingleString"
-			(Set-IshMetadataFilterField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			(Set-IshMetadataFilterField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 		It "Parameter IshFields Single Add Twice" {
 			$firstFiltervalue = "OrginalString"
 			$ishFields = Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $firstFiltervalue
 			$secondFiltervalue = "NewString"
 			$result = Set-IshMetadataFilterField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element -value $secondFiltervalue | Get-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element
-			(($result -eq $firstFiltervalue) -or ($result -eq $secondFiltervalue)) | Should Be $true
+			(($result -eq $firstFiltervalue) -or ($result -eq $secondFiltervalue)) | Should -Be $true
 		}
 		It "Parameter IshFields Multiple extra filter criteria are added" {
 			$value = "OrginalString"
 			$ishFieldA =Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$ishFieldB =Set-IshMetadataFilterField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$value = "SingleString"
-			(Set-IshMetadataFilterField -IshSession $ishSession -IshField @($ishFieldA,$ishFieldB) -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should Be 3
+			(Set-IshMetadataFilterField -IshSession $ishSession -IshField @($ishFieldA,$ishFieldB) -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should -Be 3
 		}
 		It "Pipeline IshFields Single with implicit IshSession" {
 			$ishFields = $null
 			$value = "SingleString"
-			($ishFields | Set-IshMetadataFilterField -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should Be $true
+			($ishFields | Set-IshMetadataFilterField -Name "FTITLE" -Level Logical -ValueType Element -value $value | Get-IshMetadataField -Name "FTITLE" -Level Logical -ValueType Element) -eq $value | Should -Be $true
 		}
 		It "Pipeline IshFields Multiple with implicit IshSession extra filter criteria are added" {
 			$value = "OrginalString"
 			$ishFieldA =Set-IshMetadataFilterField -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$ishFieldB =Set-IshMetadataFilterField -Name "FTITLE" -Level Logical -ValueType Element -value $value
 			$value = "SingleString"
-			(@($ishFieldA,$ishFieldB) | Set-IshMetadataFilterField -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should Be 3
+			(@($ishFieldA,$ishFieldB) | Set-IshMetadataFilterField -Name "FTITLE" -Level Logical -ValueType Element -value $value).Length | Should -Be 3
 		}
 	}
 }
 
 
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/SetIshRequestedMetadataField.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Field/SetIshRequestedMetadataField.Tests.ps1
@@ -1,68 +1,68 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Set-IshRequestedMetadataField"
-try {
+BeforeAll {
+	$cmdletName = "Set-IshRequestedMetadataField"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Set-IshRequestedMetadataField" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
+Describe "Set-IshRequestedMetadataField" -Tags "Read" {
 	Context "Set-IshRequestedMetadataField -IshSession ishSession returns IshRequestedMetadataField" {
 		It "GetType().Name" {
-			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE").GetType().Name | Should BeExactly "IshRequestedMetadataField"
+			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE").GetType().Name | Should -BeExactly "IshRequestedMetadataField"
 		}
 	}
-
-	Context “Set-IshRequestedMetadataField" {
+	Context "Set-IshRequestedMetadataField" {
 		It "Parameter IshSession/Name/Level invalid" {
-			{ Set-IshRequestedMetadataField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should Throw
+			{ Set-IshRequestedMetadataField -IshSession "INVALIDISHSESSION" -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" } | Should -Throw
 		}
 		It "Parameter ValueType invalid" {
-			{ Set-IshRequestedMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should Throw
+			{ Set-IshRequestedMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level "INVALIDFIELDLEVEL" -ValueType "INVALIDFIELDVALUETYPE" } | Should -Throw
 		}
 		It "Parameter Name" {
-			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE").Length | Should Be 1
+			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE").Length | Should -Be 1
 		}
 		It "Parameter Name Level" {
-			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical).Length | Should Be 1
+			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical).Length | Should -Be 1
 		}
 		It "Parameter Name Level ValueType" {
-			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should Be 1
+			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should -Be 1
 		}
 		It "Parameter Name Level ValueType Overwrite" {
 			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element | 
-			 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should Be 1
+			 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should -Be 1
 		}
 		It "Parameter Name Level ValueType Twice" {
 			(Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Value | 
 			 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Id | 
-			 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should Be 3
+			 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should -Be 3
 		}
 		It "Parameter IshFields Single Add" {
 			$ishFields = $null
-			(Set-IshRequestedMetadataField -IshSession $ishSession -IshField $ishFields -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should Be 1
+			(Set-IshRequestedMetadataField -IshSession $ishSession -IshField $ishFields -Name "FAUTHOR" -Level Lng -ValueType Element).Length | Should -Be 1
 		}
 		It "Parameter IshFields Single Update" {
 			$ishFields = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element
-			(Set-IshRequestedMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element).Length | Should Be 1
+			(Set-IshRequestedMetadataField -IshSession $ishSession -IshField $ishFields -Name "FTITLE" -Level Logical -ValueType Element).Length | Should -Be 1
 		}
 		It "Parameter IshFields Multiple duplicate entries will be removed" {
 			$ishFieldA =Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element
 			$ishFieldB =Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -ValueType Element
-			(Set-IshRequestedMetadataField -IshSession $ishSession -IshField @($ishFieldA,$ishFieldB) -Name "FTITLE" -Level Logical -ValueType Element).Length | Should Be 1
+			(Set-IshRequestedMetadataField -IshSession $ishSession -IshField @($ishFieldA,$ishFieldB) -Name "FTITLE" -Level Logical -ValueType Element).Length | Should -Be 1
 		}
 		It "Pipeline IshFields Single with implicit IshSession" {
 			$ishFields = $null
-			($ishFields | Set-IshRequestedMetadataField -Name "FTITLE" -Level Logical -ValueType Element).Length | Should Be 1
+			($ishFields | Set-IshRequestedMetadataField -Name "FTITLE" -Level Logical -ValueType Element).Length | Should -Be 1
 		}
 		It "Pipeline IshFields Multiple with implicit IshSession duplicate entries will be removed" {
 			$ishFieldA =Set-IshRequestedMetadataField -Name "FTITLE" -Level Logical -ValueType Element
 			$ishFieldB =Set-IshRequestedMetadataField -Name "FTITLE" -Level Logical -ValueType Element
-			(@($ishFieldA,$ishFieldB) | Set-IshRequestedMetadataField -Name "FTITLE" -Level Logical -ValueType Element).Length | Should Be 1
+			(@($ishFieldA,$ishFieldB) | Set-IshRequestedMetadataField -Name "FTITLE" -Level Logical -ValueType Element).Length | Should -Be 1
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/FileProcessor/NewIshDitaGeneralizedXml.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/FileProcessor/NewIshDitaGeneralizedXml.Tests.ps1
@@ -1,7 +1,11 @@
-Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$scriptFolderPath = Split-Path -Parent $MyInvocation.MyCommand.Path  # Needs to be outside Describe script block
-$cmdletName = "New-IshDitaGeneralizedXml"
+BeforeAll {
+	$cmdletName = "New-IshDitaGeneralizedXml"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+	
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+	$tempFolder = [System.IO.Path]::GetTempPath()
+	$scriptFolderPath = Split-Path -Parent $PSCommandPath
 
 $ditaTaskFileContent = @"
 <?xml version="1.0" ?>
@@ -25,50 +29,50 @@ $ditaGeneralizedBookMapFileContent = @"
 
 "@ # empty line space is required for comparison
 
-try {
+}	
 	
-	$tempFolder = [System.IO.Path]::GetTempPath()
 Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$rootFolder = Join-Path -Path $tempFolder -ChildPath $cmdletName 
-	New-Item -ItemType Directory -Path $rootFolder
-	$inputFolder = Join-Path -Path $rootFolder -ChildPath "input"
-	New-Item -ItemType Directory -Path $inputFolder
-	$outputFolder = Join-Path -Path $rootFolder -ChildPath "output"
-	New-Item -ItemType Directory -Path $outputFolder
-	$taskFilePath = Join-Path -Path $inputFolder -ChildPath "task==1=en.xml"
-	Set-Content -Path $taskFilePath -Value $ditaTaskFileContent -Encoding UTF8
-	$bookMapFilePath = Join-Path -Path $inputFolder -ChildPath "bookmap==1=en.xml"
-	Set-Content -Path $bookMapFilePath -Value $ditaBookMapFileContent -Encoding UTF8
-	Write-Host "Testing Catalog Existance"
-	# Location of the catalog xml that contains the specialized dtds
-	$specializedCatalogFilePath = Join-Path -Path $scriptFolderPath -ChildPath "..\..\Samples\Data-GeneralizeDitaXml\SpecializedDTDs\catalog-alldita12dtds.xml"
-	# Location of the catalog xml that contains the "base" dtds
-    $generalizedCatalogFilePath = Join-Path -Path $scriptFolderPath -ChildPath "..\..\Samples\Data-GeneralizeDitaXml\GeneralizedDTDs\catalog-dita12topic&maponly.xml"
-	# File that contains a mapping between the specialized dtd and the according generalized dtd.
-    $generalizationCatalogMappingFilePath = Join-Path -Path $scriptFolderPath -ChildPath "..\..\Samples\Data-GeneralizeDitaXml\generalization-catalog-mapping.xml"
-	if (-Not (Test-Path -Path $specializedCatalogFilePath -PathType Leaf)) { Write-Warning ("Catalog specializedCatalogFilePath[$specializedCatalogFilePath] missing!") }
-	if (-Not (Test-Path -Path $generalizedCatalogFilePath -PathType Leaf)) { Write-Warning ("Catalog generalizedCatalogFilePath[$generalizedCatalogFilePath] missing!") }
-	if (-Not (Test-Path -Path $generalizationCatalogMappingFilePath -PathType Leaf)) { Write-Warning ("Catalog generalizationCatalogMappingFilePath[$generalizationCatalogMappingFilePath] missing!") }
-	# If you would have specialized attributes from the DITA 1.2 "props" attribute, specify those attributes here to generalize them to the "props" attribute again.  Here just using modelyear, market, vehicle as an example
-	$attributesToGeneralizeToProps = @("modelA", "modelB", "modelC")
-	# If you would have specialized attributes from the DITA 1.2 "base" attribute, specify those attributes here to generalize them to the "base" attribute again. Here just using basea, baseb, basec as an example
-	$attributesToGeneralizeToBase = @("basea", "baseb", "basec")
-
-	  
+	BeforeAll {
+		$rootFolder = Join-Path -Path $tempFolder -ChildPath $cmdletName 
+		New-Item -ItemType Directory -Path $rootFolder
+		$inputFolder = Join-Path -Path $rootFolder -ChildPath "input"
+		New-Item -ItemType Directory -Path $inputFolder
+		$outputFolder = Join-Path -Path $rootFolder -ChildPath "output"
+		New-Item -ItemType Directory -Path $outputFolder
+		$taskFilePath = Join-Path -Path $inputFolder -ChildPath "task==1=en.xml"
+		Set-Content -Path $taskFilePath -Value $ditaTaskFileContent -Encoding UTF8
+		$bookMapFilePath = Join-Path -Path $inputFolder -ChildPath "bookmap==1=en.xml"
+		Set-Content -Path $bookMapFilePath -Value $ditaBookMapFileContent -Encoding UTF8
+		Write-Host "Testing Catalog Existance"
+		# Location of the catalog xml that contains the specialized dtds
+		$specializedCatalogFilePath = Join-Path -Path $scriptFolderPath -ChildPath "..\..\Samples\Data-GeneralizeDitaXml\SpecializedDTDs\catalog-alldita12dtds.xml"
+		# Location of the catalog xml that contains the "base" dtds
+		$generalizedCatalogFilePath = Join-Path -Path $scriptFolderPath -ChildPath "..\..\Samples\Data-GeneralizeDitaXml\GeneralizedDTDs\catalog-dita12topic&maponly.xml"
+		# File that contains a mapping between the specialized dtd and the according generalized dtd.
+		$generalizationCatalogMappingFilePath = Join-Path -Path $scriptFolderPath -ChildPath "..\..\Samples\Data-GeneralizeDitaXml\generalization-catalog-mapping.xml"
+		if (-Not (Test-Path -Path $specializedCatalogFilePath -PathType Leaf)) { Write-Warning ("Catalog specializedCatalogFilePath[$specializedCatalogFilePath] missing!") }
+		if (-Not (Test-Path -Path $generalizedCatalogFilePath -PathType Leaf)) { Write-Warning ("Catalog generalizedCatalogFilePath[$generalizedCatalogFilePath] missing!") }
+		if (-Not (Test-Path -Path $generalizationCatalogMappingFilePath -PathType Leaf)) { Write-Warning ("Catalog generalizationCatalogMappingFilePath[$generalizationCatalogMappingFilePath] missing!") }
+		# If you would have specialized attributes from the DITA 1.2 "props" attribute, specify those attributes here to generalize them to the "props" attribute again.  Here just using modelyear, market, vehicle as an example
+		$attributesToGeneralizeToProps = @("modelA", "modelB", "modelC")
+		# If you would have specialized attributes from the DITA 1.2 "base" attribute, specify those attributes here to generalize them to the "base" attribute again. Here just using basea, baseb, basec as an example
+		$attributesToGeneralizeToBase = @("basea", "baseb", "basec")
+	}
 	Context "New-IshDitaGeneralizedXml" {
-		$taskFileInfo = New-IshDitaGeneralizedXml -SpecializedCatalogFilePath $specializedCatalogFilePath `
-											  -GeneralizedCatalogFilePath $generalizedCatalogFilePath `
-											  -GeneralizationCatalogMappingFilePath $generalizationCatalogMappingFilePath `
-											  -AttributesToGeneralizeToProps $attributesToGeneralizeToProps `
-											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
-											  -FolderPath $outputFolder `
-											  -FilePath $taskFilePath
+		BeforeAll {
+			$taskFileInfo = New-IshDitaGeneralizedXml -SpecializedCatalogFilePath $specializedCatalogFilePath `
+												-GeneralizedCatalogFilePath $generalizedCatalogFilePath `
+												-GeneralizationCatalogMappingFilePath $generalizationCatalogMappingFilePath `
+												-AttributesToGeneralizeToProps $attributesToGeneralizeToProps `
+												-AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
+												-FolderPath $outputFolder `
+												-FilePath $taskFilePath
+		}
 		It "GetType().Name" {
-			$taskFileInfo.GetType().Name | Should BeExactly "FileInfo"
+			$taskFileInfo.GetType().Name | Should -BeExactly "FileInfo"
 		}
 		It "Task Result String Comparison" {
-			(Get-Content -Path $taskFileInfo -Raw) -eq $ditaGeneralizedTaskFileContent | Should Be $True
+			(Get-Content -Path $taskFileInfo -Raw) -eq $ditaGeneralizedTaskFileContent | Should -Be $True
 		}
 		It "BookMap without Attributes options Result String Comparison" {
 			$bookMapFileInfo = Get-Item $bookMapFilePath | 
@@ -76,7 +80,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 							                             -GeneralizedCatalogFilePath $generalizedCatalogFilePath `
 														 -GeneralizationCatalogMappingFilePath $generalizationCatalogMappingFilePath `
 														 -FolderPath $outputFolder
-			(Get-Content -Path $bookMapFileInfo -Raw) -eq $ditaGeneralizedBookMapFileContent | Should Be $True
+			(Get-Content -Path $bookMapFileInfo -Raw) -eq $ditaGeneralizedBookMapFileContent | Should -Be $True
 		}
 		It "Parameter SpecializedCatalogFilePath invalid" {
 			{
@@ -87,7 +91,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
 											  -FolderPath $outputFolder `
 											  -FilePath $taskFilePath
-			} | Should Throw
+			} | Should -Throw
 		}
 		It "Parameter GeneralizedCatalogFilePath invalid" {
 			{
@@ -98,7 +102,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
 											  -FolderPath $outputFolder `
 											  -FilePath $taskFilePath
-			} | Should Throw
+			} | Should -Throw
 		}
 		It "Parameter GeneralizationCatalogMappingFilePath invalid" {
 			{
@@ -109,7 +113,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
 											  -FolderPath $outputFolder `
 											  -FilePath $taskFilePath
-			} | Should Throw
+			} | Should -Throw
 		}
 		It "Parameter FilePath invalid will result in warning" {
 			{
@@ -120,7 +124,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
 											  -FolderPath $outputFolder `
 											  -FilePath "INVALIDILEPATH"
-			} | Should Not Throw
+			} | Should -Not -Throw
 		}
 		It "Parameter FilePath Single" {
 			$fileInfoArray = New-IshDitaGeneralizedXml -SpecializedCatalogFilePath $specializedCatalogFilePath `
@@ -130,7 +134,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
 											  -FolderPath $outputFolder `
 											  -FilePath $taskFilePath
-			$fileInfoArray.Count | Should Be 1
+			$fileInfoArray.Count | Should -Be 1
 		}
 		It "Parameter FilePath Multiple" {
 			$fileInfoArray = New-IshDitaGeneralizedXml -SpecializedCatalogFilePath $specializedCatalogFilePath `
@@ -140,7 +144,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
 											  -FolderPath $outputFolder `
 											  -FilePath @($taskFilePath,$bookMapFilePath)
-			$fileInfoArray.Count | Should Be 2
+			$fileInfoArray.Count | Should -Be 2
 		}
 		It "Pipeline FilePath Single" {
 			$fileInfos = Get-Item -Path $taskFilePath
@@ -149,7 +153,7 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -GeneralizationCatalogMappingFilePath $generalizationCatalogMappingFilePath `
 											  -AttributesToGeneralizeToProps $attributesToGeneralizeToProps `
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
-											  -FolderPath $outputFolder).Count | Should Be 1
+											  -FolderPath $outputFolder).Count | Should -Be 1
 		}
 		It "Pipeline FilePath Multiple" {
 			$fileInfos = @((Get-Item -Path $taskFilePath), (Get-Item -Path $bookMapFilePath))
@@ -158,13 +162,13 @@ Describe "New-IshDitaGeneralizedXml" -Tags "Read" {
 											  -GeneralizationCatalogMappingFilePath $generalizationCatalogMappingFilePath `
 											  -AttributesToGeneralizeToProps $attributesToGeneralizeToProps `
 											  -AttributesToGeneralizeToBase $attributesToGeneralizeToBase `
-											  -FolderPath $outputFolder).Count | Should Be 2
+											  -FolderPath $outputFolder).Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	try { Remove-Item (Join-Path $tempFolder $cmdletName) -Recurse -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/AddIshFolder.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/AddIshFolder.Tests.ps1
@@ -1,129 +1,132 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshFolder"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshFolder"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Add-IshFolder" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	Context “Add-IshFolder ParameterGroup" {
+Describe "Add-IshFolder" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+		$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+	}
+	Context "Add-IshFolder ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshFolder -IShSession "INVALIDISHSESSION" -ParentFolderId "-6" -FolderType ISHNone -FolderName "INVALIDFOLDERNAME" -OwnedBy "INVALIDUSERGROUP" -ReadAccess @("INVALIDUSERGROUPA","INVALIDUSERGROUPB") } | Should Throw
+			{ Add-IshFolder -IShSession "INVALIDISHSESSION" -ParentFolderId "-6" -FolderType ISHNone -FolderName "INVALIDFOLDERNAME" -OwnedBy "INVALIDUSERGROUP" -ReadAccess @("INVALIDUSERGROUPA","INVALIDUSERGROUPB") } | Should -Throw
 		}
 	}
-
-	$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 	Context "Add-IshFolder returns IshFolder object" {
 		It "GetType().Name" {
-			$ishFolderCmdlet.GetType().Name | Should BeExactly "IshFolder"
+			$ishFolderCmdlet.GetType().Name | Should -BeExactly "IshFolder"
 		}
 		It "ishFolderCmdlet.IshFolderRef" {
-			$ishFolderCmdlet.IshFolderRef -ge 0 | Should Be $true
+			$ishFolderCmdlet.IshFolderRef -ge 0 | Should -Be $true
 		}
 		It "ishFolderCmdlet.IshFolderType" {
-			$ishFolderCmdlet.IshFolderType | Should Not BeNullOrEmpty
+			$ishFolderCmdlet.IshFolderType | Should -Not -BeNullOrEmpty
 		}
 		It "ishFolderCmdlet.IshField" {
-			$ishFolderCmdlet.IshField | Should Not BeNullOrEmpty
+			$ishFolderCmdlet.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishFolderCmdlet.name.Length -ge 1 | Should Be $true 
-			$ishFolderCmdlet.fdocumenttype.Length -ge 1 | Should Be $true 
-			$ishFolderCmdlet.fdocumenttype_none_element.StartsWith('VDOCTYPE') | Should Be $true 
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishFolderCmdlet.name.Length -ge 1 | Should -Be $true 
+			$ishFolderCmdlet.fdocumenttype.Length -ge 1 | Should -Be $true 
+			$ishFolderCmdlet.fdocumenttype_none_element.StartsWith('VDOCTYPE') | Should -Be $true 
 		}
 	}
-
-	Context “Add-IshFolder ParameterGroup" {
+	Context "Add-IshFolder ParameterGroup" {
 		It "Parameter ParentFolderId invalid" {
-			{ Add-IshFolder -IShSession $ishSession -ParentFolderId "INVALIDFOLDERID" } | Should Throw
+			{ Add-IshFolder -IShSession $ishSession -ParentFolderId "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter ParentFolderId invalid" {
-			{ Add-IshFolder -IShSession $ishSession -ParentFolderId "INVALIDFOLDERID" } | Should Throw
+			{ Add-IshFolder -IShSession $ishSession -ParentFolderId "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter FolderType ISHIllustration" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "ParameterGroup ISHIllustration" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHLibrary" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "ParameterGroup ISHLibrary" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHMasterDoc" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "ParameterGroup ISHMasterDoc" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHModule" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "ParameterGroup ISHModule" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHNone" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHNone -FolderName "ParameterGroup ISHNone" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHPublication" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "ParameterGroup ISHPublication" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHTemplate" {
 			$ishFolders = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "ParameterGroup ISHTemplate" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter FolderType ISHQuery" {
-			{ Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHQuery -FolderName "ParameterGroup ISHQuery" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal }  | Should Throw
+			{ Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHQuery -FolderName "ParameterGroup ISHQuery" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal }  | Should -Throw
 		}
 		It "Parameter FolderType ISHReference" {
-			{ Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHReference -FolderName "ParameterGroup ISHReference" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal }  | Should Throw
+			{ Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHReference -FolderName "ParameterGroup ISHReference" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal }  | Should -Throw
 		}
 	}
 
 	# Most cmdldets take IshFolder pipeline to apply on, this one will apply the incoming IshFolder to become subfolders of the ParentFolder
-	Context “Add-IshFolder IshFoldersGroup" {
-		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
-		$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
-		$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
-		$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+	Context "Add-IshFolder IshFoldersGroup" {
+		BeforeAll {
+			$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
+			$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
+			$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
+			$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+		}
 		It "Parameter IshFolder invalid" {
-			{ Add-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should Throw
+			{ Add-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter IshFolder Single with implicit IshSession" {
 			$ishFolderEditorTemplate = $ishFolderEditorTemplate | Set-IshMetadataField -Name "FNAME" -Level None -Value "EditorTemplate IshFoldersGroup Parameter IshFolder Single"
 			$ishFolders = Add-IshFolder -IshFolder $ishFolderEditorTemplate -ParentFolderId $ishFolderCmdlet.IshFolderRef
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter IshFolder Multiple with implicit IshSession" {
 			$ishFolderEditorTemplate = $ishFolderEditorTemplate | Set-IshMetadataField -Name "FNAME" -Level None -Value "EditorTemplate IshFoldersGroup Parameter IshFolder Multiple"
 			$ishFolderFavorites = $ishFolderFavorites | Set-IshMetadataField -Name "FNAME" -Level None -Value "Favorites IshFoldersGroup Parameter IshFolder Multiple"
 			$ishFolders = Add-IshFolder -IshFolder @($ishFolderEditorTemplate,$ishFolderFavorites) -ParentFolderId $ishFolderCmdlet.IshFolderRef
-			$ishFolders.Count | Should Be 2
+			$ishFolders.Count | Should -Be 2
 		}
 		It "Pipeline IshFolder Single" {
 			$ishFolderData = $ishFolderData | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "EditorTemplate IshFoldersGroup Pipeline IshFolder Single"
 			$ishFolders = $ishFolderData | Add-IshFolder -IshSession $ishSession -ParentFolderId $ishFolderCmdlet.IshFolderRef
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Pipeline IshFolder Multiple" {
 			$ishFolderData = $ishFolderData | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "EditorTemplate IshFoldersGroup Pipeline IshFolder Multiple"
 			$ishFolderSystem = $ishFolderSystem | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "System IshFoldersGroup Pipeline IshFolder Multiple"
 			$ishFolders = @($ishFolderData,$ishFolderSystem) | Add-IshFolder -IshSession $ishSession -ParentFolderId $ishFolderCmdlet.IshFolderRef
-			$ishFolders.Count | Should Be 2
+			$ishFolders.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolder.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolder.Tests.ps1
@@ -1,253 +1,257 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshFolder"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshFolder"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshFolder" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "aLL yOUR bASE bELONG tO uS!" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "All" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Your" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Base" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Belong" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "To" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Us!" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Get-IshFolder" -Tags "Read" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	Context “Get-IshFolder ParameterGroup" {
+		$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "aLL yOUR bASE bELONG tO uS!" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "All" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Your" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Base" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Belong" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "To" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Us!" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
+	}
+	Context "Get-IshFolder ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshFolder -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Get-IshFolder -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshFolder returns IshFolder object" {
-		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
 		It "GetType()" {
-			$ishFolderData.GetType().Name | Should BeExactly "IshFolder"
+			$ishFolderData.GetType().Name | Should -BeExactly "IshFolder"
 		}
 		It "ishFolderData.IshFolderRef" {
-			$ishFolderData.IshFolderRef -ge 0 | Should Be $true
+			$ishFolderData.IshFolderRef -ge 0 | Should -Be $true
 		}
 		It "ishFolderData.IshFolderType" {
-			$ishFolderData.IshFolderType | Should Not BeNullOrEmpty
+			$ishFolderData.IshFolderType | Should -Not -BeNullOrEmpty
 		}
 		It "ishFolderData.IshField" {
-			$ishFolderData.IshField | Should Not BeNullOrEmpty
+			$ishFolderData.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishFolderData.name.Length -ge 1 | Should Be $true 
-			$ishFolderData.fdocumenttype.Length -ge 1 | Should Be $true 
-			$ishFolderData.fdocumenttype_none_element.StartsWith('VDOCTYPE') | Should Be $true 
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishFolderData.name.Length -ge 1 | Should -Be $true 
+			$ishFolderData.fdocumenttype.Length -ge 1 | Should -Be $true 
+			$ishFolderData.fdocumenttype_none_element.StartsWith('VDOCTYPE') | Should -Be $true 
 		}
 	}
-
-	Context “Get-IshFolder BaseFolderGroup" {
+	Context "Get-IshFolder BaseFolderGroup" {
 		It "Parameter BaseFolder invalid" {
-			{ Get-IshFolder -IShSession $ishSession -BaseFolder None } | Should Throw
+			{ Get-IshFolder -IShSession $ishSession -BaseFolder None } | Should -Throw
 		}		
 		It "Parameter BaseFolder Data" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef -ge 0 | Should -Be $true
 		}
 		It "Parameter BaseFolder System" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef -ge 0 | Should -Be $true
 		}
 		It "Parameter BaseFolder Favorites" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef -ge 0 | Should -Be $true
 		}
 		It "Parameter BaseFolder EditorTemplate" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef -ge 0 | Should -Be $true
 		}
 	}
-
-	Context “Get-IshFolder FolderPathGroup" {
+	Context "Get-IshFolder FolderPathGroup" {
 		It "Parameter FolderPath invalid" {
-			{ Get-IshFolder -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should Throw "-102001"
+			$exception = { Get-IshFolder -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-102001] The folder 'INVALIDFOLDERPATH' does not exist. [name:"'INVALIDFOLDERPATH'"] [102001;InvalidObject]
+			$exception -like "*102001*" | Should -Be $true 
+			$exception -like "*InvalidObject*" | Should -Be $true
 		}
 		It "Parameter FolderPath $folderTestRootPath" {
-			(Get-IshFolder -IshSession $ishSession -FolderPath $folderTestRootPath).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IshSession $ishSession -FolderPath $folderTestRootPath).IshFolderRef -ge 0 | Should -Be $true
 		}
 	}
-
-	Context “Get-IshFolder FolderIdsGroup" {
-		[long]$ishFolderDataFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef
-		[long]$ishFolderSystemFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef
-		[long]$ishFolderFavoritesFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef
-		[long]$ishFolderEditorTemplateFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef
+	Context "Get-IshFolder FolderIdsGroup" {
+		BeforeAll {
+			[long]$ishFolderDataFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef
+			[long]$ishFolderSystemFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef
+			[long]$ishFolderFavoritesFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef
+			[long]$ishFolderEditorTemplateFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef
+		}
 		It "Parameter FolderId invalid" {
-			{ Get-IshFolder -IShSession $ishSession -FolderId "INVALIDFOLDERID" } | Should Throw
+			{ Get-IshFolder -IShSession $ishSession -FolderId "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter FolderId zero" {
-			{ Get-IshFolder -IShSession $ishSession -FolderId 0 } | Should Throw
+			{ Get-IshFolder -IShSession $ishSession -FolderId 0 } | Should -Throw
 		}
 		It "Parameter FolderId from Data" {
-			(Get-IshFolder -IshSession $ishSession -FolderId $ishFolderDataFolderRef).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IshSession $ishSession -FolderId $ishFolderDataFolderRef).IshFolderRef -ge 0 | Should -Be $true
 		}
-	
 		<# FolderId is defined as long, not long[], so don't even know if PowerShell automatically converts
 		It "Parameter FolderId from Data.System" {
-			(Get-IshFolder -IshSession $ishSession -FolderId [long[]]@($ishFolderDataFolderRef,$ishFolderSystemFolderRef)).Count -eq 2 | Should Be $true
+			(Get-IshFolder -IshSession $ishSession -FolderId [long[]]@($ishFolderDataFolderRef,$ishFolderSystemFolderRef)).Count -eq 2 | Should -Be $true
 		}
 		#>
 		It "Pipeline FolderId" {
 			$ishFolders = @($ishFolderDataFolderRef,$ishFolderSystemFolderRef,$ishFolderFavoritesFolderRef,$ishFolderEditorTemplateFolderRef) | Get-IshFolder -IshSession $ishSession
-			$ishFolders.Count -eq 4 | Should Be $true
+			$ishFolders.Count -eq 4 | Should -Be $true
 		}
 		It "Pipeline FolderId MetadataBatchSize[1]" {
 			$ishSession.MetadataBatchSize = 1
 			$ishFolders = @($ishFolderDataFolderRef,$ishFolderSystemFolderRef,$ishFolderFavoritesFolderRef,$ishFolderEditorTemplateFolderRef) | Get-IshFolder -IshSession $ishSession
-			$ishFolders.Count -eq 4 | Should Be $true
+			$ishFolders.Count -eq 4 | Should -Be $true
 		}
 	}
-
-	Context “Get-IshFolder IshFoldersGroup" {
-		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
-		$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
-		$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
-		$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+	Context "Get-IshFolder IshFoldersGroup" {
+		BeforeAll {
+			$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
+			$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
+			$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
+			$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+		}
 		It "Parameter IshFolder invalid" {
-			{ Get-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should Throw
+			{ Get-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter IshFolder Single with implicit IshSession" {
-			(Get-IshFolder -IshFolder $ishFolderData).IshFolderRef -ge 0 | Should Be $true
+			(Get-IshFolder -IshFolder $ishFolderData).IshFolderRef -ge 0 | Should -Be $true
 		}
 		It "Parameter IshFolder Multiple with implicit IshSession" {
-			(Get-IshFolder -IshFolder @($ishFolderData,$ishFolderSystem,$ishFolderFavorites,$ishFolderEditorTemplate)).Count -eq 4 | Should Be $true
+			(Get-IshFolder -IshFolder @($ishFolderData,$ishFolderSystem,$ishFolderFavorites,$ishFolderEditorTemplate)).Count -eq 4 | Should -Be $true
 		}
 		It "Pipeline IshFolder Single" {
 			$ishFolders = $ishFolderData | Get-IshFolder -IshSession $ishSession
-			$ishFolders.Count -eq 1 | Should Be $true
+			$ishFolders.Count -eq 1 | Should -Be $true
 		}
 		It "Pipeline IshFolder Multiple" {
 			$ishSession.MetadataBatchSize = 2
 			$ishFolders = @($ishFolderData,$ishFolderSystem,$ishFolderFavorites,$ishFolderEditorTemplate) | Get-IshFolder -IshSession $ishSession
-			$ishFolders.Count -eq 4 | Should Be $true
+			$ishFolders.Count -eq 4 | Should -Be $true
 		}
 	}
-
 	Context "Get-IshFolder EditorTemplate Recurse" {
-		$ishFolderEditorTemplateRecursive = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse
+		BeforeAll {
+			$ishFolderEditorTemplateRecursive = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse
+		}
 		It "GetType()" {
-			$ishFolderEditorTemplateRecursive[0].GetType().Name | Should BeExactly "IshFolder"
+			$ishFolderEditorTemplateRecursive[0].GetType().Name | Should -BeExactly "IshFolder"
 		}
 		It "Get-IshFolder EditorTemplate Count" {
-			$ishFolderEditorTemplateRecursive.Count -ge 4 | Should Be $true
+			$ishFolderEditorTemplateRecursive.Count -ge 4 | Should -Be $true
 		}
 		It "Get-IshFolder EditorTemplate Count Depth=-1" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth -1).Count | Should Be 0
+			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth -1).Count | Should -Be 0
 		}
 		It "Get-IshFolder EditorTemplate Count Depth=0" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth 0).Count | Should Be 0
+			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth 0).Count | Should -Be 0
 		}
 		It "Get-IshFolder EditorTemplate Count Depth=1" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth 1).Count | Should Be 1
+			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth 1).Count | Should -Be 1
 		}
 		It "Get-IshFolder EditorTemplate Count Depth=2" {
-			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth 2).Count  -ge 4 | Should Be $true
+			(Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse -Depth 2).Count  -ge 4 | Should -Be $true
 		}
 	}
-
 	Context "Get-IshFolder Recurse Sort and Traversal" {
-		$ishFolderEditorTemplateRecursive = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse
+		BeforeAll {
+			$ishFolderEditorTemplateRecursive = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate -Recurse
+		}
 		It "GetType()" {
-			$ishFolderEditorTemplateRecursive[0].GetType().Name | Should BeExactly "IshFolder"
+			$ishFolderEditorTemplateRecursive[0].GetType().Name | Should -BeExactly "IshFolder"
 		}
 		It "Get-IshFolder ishFolderCmdlet Count" {
-			$ishFolderEditorTemplateRecursive.Count -ge 6 | Should Be $true
+			$ishFolderEditorTemplateRecursive.Count -ge 6 | Should -Be $true
 		}
 		It "Get-IshFolder ishFolderCmdlet Count Depth=2" {
-			(Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse -Depth 2).Count | Should Be 3
+			(Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse -Depth 2).Count | Should -Be 3
 		}
 		It "Get-IshFolder ishFolderCmdlet Traversal 'All'" {
-			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse)[1].IshField) | Should MatchExactly "All"
+			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse)[1].IshField) | Should -MatchExactly "All"
 		}
 		It "Get-IshFolder ishFolderCmdlet Traversal 'aLL'" {
-			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse)[7].IshField) | Should MatchExactly "aLL yOUR bASE bELONG tO uS!"
+			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse)[7].IshField) | Should -MatchExactly "aLL yOUR bASE bELONG tO uS!"
 		}
 		It "Get-IshFolder ishFolderCmdlet Traversal 'All' with FolderTypeFilter" {
-			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHNone") -Recurse)[1].IshField) | Should MatchExactly "All"
+			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHNone") -Recurse)[1].IshField) | Should -MatchExactly "All"
 		}
 		It "Get-IshFolder ishFolderCmdlet Traversal 'aLL' with FolderTypeFilter" {
-			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHNone") -Recurse)[7].IshField) | Should MatchExactly "aLL yOUR bASE bELONG tO uS!"
+			Get-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -IshField((Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHNone") -Recurse)[7].IshField) | Should -MatchExactly "aLL yOUR bASE bELONG tO uS!"
 		}
 	}
-
 	Context "Get-IshFolder System Recurse Pipeline" {
 		It "Get-IshFolder System Recurse Pipeline to Get-IshFolderContent" {
 			# Check Fiddler that Folder calls alternate with DocumentObj calls confirming the pipeline
 			$ishObjects = Get-IshFolder -IShSession $ishSession -BaseFolder System -Recurse | Get-IshFolderContent -IshSession $ishSession
-			$ishObjects.Count -ge 1 | Should Be $true
+			$ishObjects.Count -ge 1 | Should -Be $true
 		}
 	}
-
     Context "Get-IshFolder with requesting FolderTypeFilter and Recursion" {
         It "Get-IshFolder with incorrect FolderTypeFilter" {
-           {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "ISHWrongType" -Recurse} | Should Throw
+           {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "ISHWrongType" -Recurse} | Should -Throw
         }
 		It "Get-IshFolder with incorrect value in array FolderTypeFilter" {
-            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHWrongType") -Recurse} | Should Throw
+            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHWrongType") -Recurse} | Should -Throw
         }
 		It "Get-IshFolder with empty FolderTypeFilter" {
-            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "" -Recurse} | Should Throw
+            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "" -Recurse} | Should -Throw
         }
         It "Get-IshFolder with filtering on all Xml content folders" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate") -Recurse).Count | Should Be 7
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate") -Recurse).Count | Should -Be 7
         }
         It "Get-IshFolder with filtering on all Xml content folders with Depth=2" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate") -Recurse -Depth 2).Count | Should Be 2
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate") -Recurse -Depth 2).Count | Should -Be 2
         }
         It "Get-IshFolder with filtering on all folders with Depth=2" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate", "ISHNone", "ISHIllustration") -Recurse -Depth 2).Count | Should Be 3
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate", "ISHNone", "ISHIllustration") -Recurse -Depth 2).Count | Should -Be 3
         }
 		It "Get-IshFolder without filtering on FolderType" {
-			(Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse).Count | Should Be 8
+			(Get-IshFolder -IShSession $ishSession -IshFolder $ishFolderCmdlet -Recurse).Count | Should -Be 8
         }
 		It "Get-IshFolder with filtering on only ISHModule folders" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule") -Recurse).Count | Should Be 7
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule") -Recurse).Count | Should -Be 7
         }
         It "Get-IshFolder with filtering on only ISHNone folders" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHNone") -Recurse).Count | Should Be 1
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHNone") -Recurse).Count | Should -Be 1
         }
         It "Get-IshFolder with filtering out all folders" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHIllustration") -Recurse).Count | Should Be 0
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHIllustration") -Recurse).Count | Should -Be 0
 		}
     }
     Context "Get-IshFolder with requesting FolderTypeFilter and with no Recursion" {
         It "Get-IshFolder with incorrect FolderTypeFilter" {
-           {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "ISHWrongType" } | Should Throw
+           {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "ISHWrongType" } | Should -Throw
         }
 		It "Get-IshFolder with incorrect value in array FolderTypeFilter" {
-            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHWrongType") } | Should Throw
+            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHWrongType") } | Should -Throw
         }
 		It "Get-IshFolder with empty FolderTypeFilter" {
-            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "" } | Should Throw
+            {Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter "" } | Should -Throw
         }
         It "Get-IshFolder with filtering on only ISHNone folders" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHNone")).Count | Should Be 1
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHNone")).Count | Should -Be 1
         }
         It "Get-IshFolder with filtering out all folders" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHIllustration")).Count | Should Be 0
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHIllustration")).Count | Should -Be 0
 		}
         It "Get-IshFolder with filtering out all folders(Filter array)" {
-			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate")).Count | Should Be 0
+			(Get-IshFolder -IshSession $ishSession -IshFolder $ishFolderCmdlet -FolderTypeFilter @("ISHModule", "ISHMasterDoc", "ISHLibrary", "ISHTemplate")).Count | Should -Be 0
         }
     }
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.Tests.ps1
@@ -1,318 +1,321 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshFolderContent"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshFolderContent"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshFolderContent" -Tags "Read" {
-	# TODO explicit count test, so initialize Get-IshFolderContent test folders with accurate count for -eq testing
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishTopicCount = 3
-	for($current=1;$current -le $ishTopicCount;$current++)
-	{
-		# Create topic
-		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $current" |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-		$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
-		# Create extra version
-		Add-IshDocumentObj -IshSession $ishSession -LogicalId $ishObject.IshRef -Version "2" -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
-	}
+Describe "Get-IshFolderContent" -Tags "Read" {
+	BeforeAll {
+		# TODO [Could] explicit count test, so initialize Get-IshFolderContent test folders with accurate count for -eq testing
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	Context “Get-IshFolderContent ParameterGroup" {
-		It "Parameter IshSession invalid" {
-			{ Get-IshFolderContent -IShSession "INVALIDISHSESSION" } | Should Throw
+		$ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishTopicCount = 3
+		for($current=1;$current -le $ishTopicCount;$current++)
+		{
+			# Create topic
+			$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $current" |
+								Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+								Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+			$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+			# Create extra version
+			Add-IshDocumentObj -IshSession $ishSession -LogicalId $ishObject.IshRef -Version "2" -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
 		}
 	}
-
+	Context "Get-IshFolderContent ParameterGroup" {
+		It "Parameter IshSession invalid" {
+			{ Get-IshFolderContent -IShSession "INVALIDISHSESSION" } | Should -Throw
+		}
+	}
 	Context "Get-IshFolderContent returns latest IshObject[] object" {
-		$requestedMetadata = Set-IshRequestedMetadataField -Level Lng -Name FISHSTATUSTYPE
-		$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -RequestedMetadata $requestedMetadata
+		BeforeAll {
+			$requestedMetadata = Set-IshRequestedMetadataField -Level Lng -Name FISHSTATUSTYPE
+			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -RequestedMetadata $requestedMetadata
+		}
 		It "GetType().Name" {
-			$ishObjects.GetType().Name | Should BeExactly "Object[]"
+			$ishObjects.GetType().Name | Should -BeExactly "Object[]"
 		}
 		It "ishObjects.Count" {
-			$ishObjects.Length | Should BeExactly $ishTopicCount  
+			$ishObjects.Length | Should -BeExactly $ishTopicCount  
 		}
 		It "[0]GetType().BaseType.Name" {
 			# Used to be IshObject, but more specific ISHType like IshDocumentObj or IshPublicationOutput is put on the pipeline
-			$ishObjects[0].GetType().Name | Should BeExactly "IshDocumentObj"  
+			$ishObjects[0].GetType().Name | Should -BeExactly "IshDocumentObj"  
 		}
 		It "ishObjects[0].IshData" {
-			{ $ishObjects[0].IshData } | Should Not Throw
+			{ $ishObjects[0].IshData } | Should -Not -Throw
 		}
 		It "ishObjects[0].IshField" {
-			$ishObjects[0].IshField | Should Not BeNullOrEmpty
+			$ishObjects[0].IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0].IshRef" {
-			$ishObjects[0].IshRef | Should Not BeNullOrEmpty
+			$ishObjects[0].IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0].IshType" {
-			$ishObjects[0].IshType | Should Not BeNullOrEmpty
+			$ishObjects[0].IshType | Should -Not -BeNullOrEmpty
 		}
-		# Double check following 3 ReferenceType enum usage 
 		It "ishObjects[0].ObjectRef" {
-			$ishObjects[0].ObjectRef | Should Not BeNullOrEmpty
+			# Double check following 3 ReferenceType enum usage 
+			$ishObjects[0].ObjectRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0].VersionRef" {
-			$ishObjects[0].VersionRef | Should Not BeNullOrEmpty
+			$ishObjects[0].VersionRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0].LngRef" {
-			$ishObjects[0].LngRef | Should Not BeNullOrEmpty
+			$ishObjects[0].LngRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0] ConvertTo-Json" {
-			(ConvertTo-Json $ishObjects[0]).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishObjects[0]).Length -gt 2 | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObjects[0].ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObjects[0].ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObjects[0].version_version_value.Length -ge 1 | Should Be $true 
-			$ishObjects[0].version_version_value -ge 2 | Should Be $true 
+			$ishObjects[0].version_version_value.Length -ge 1 | Should -Be $true 
+			$ishObjects[0].version_version_value -ge 2 | Should -Be $true 
 			#language
-			$ishObjects[0].fstatus.Length -ge 1 | Should Be $true 
-			$ishObjects[0].fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true
-			$ishObjects[0].fishstatustype -ge 0 | Should Be $true
+			$ishObjects[0].fstatus.Length -ge 1 | Should -Be $true 
+			$ishObjects[0].fstatus_lng_element.StartsWith('VSTATUS') | Should -Be $true
+			$ishObjects[0].fishstatustype -ge 0 | Should -Be $true
 		}
 	}
-
 	Context "Get-IshFolderContent with empty VersionFilter returns IshObject[] object" {
-		$requestedMetadata = Set-IshRequestedMetadataField -Level Lng -Name FISHSTATUSTYPE
-		$ishObjects = Get-IshFolderContent -IShSession $ishSession -VersionFilter "" -IshFolder $ishFolderTopic -RequestedMetadata $requestedMetadata
+		BeforeAll {
+			$requestedMetadata = Set-IshRequestedMetadataField -Level Lng -Name FISHSTATUSTYPE
+			$ishObjects = Get-IshFolderContent -IShSession $ishSession -VersionFilter "" -IshFolder $ishFolderTopic -RequestedMetadata $requestedMetadata
+		}
 		It "GetType().Name" {
-			$ishObjects.GetType().Name | Should BeExactly "Object[]"
+			$ishObjects.GetType().Name | Should -BeExactly "Object[]"
 		}
 		It "ishObjects.Count" {
             $totalLngObjects = $ishTopicCount*2
-			$ishObjects.Length | Should BeExactly $totalLngObjects
+			$ishObjects.Length | Should -BeExactly $totalLngObjects
 		}
 		It "[0]GetType().BaseType.Name" {
 			# Used to be IshObject, but more specific ISHType like IshDocumentObj or IshPublicationOutput is put on the pipeline
-			$ishObjects[0].GetType().Name | Should BeExactly "IshDocumentObj"  
+			$ishObjects[0].GetType().Name | Should -BeExactly "IshDocumentObj"  
 		}
 		It "ishObjects[0].IshData" {
-			{ $ishObjects[0].IshData } | Should Not Throw
+			{ $ishObjects[0].IshData } | Should -Not -Throw
 		}
 		It "ishObjects[0].IshField" {
-			$ishObjects[0].IshField | Should Not BeNullOrEmpty
+			$ishObjects[0].IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0].IshRef" {
-			$ishObjects[0].IshRef | Should Not BeNullOrEmpty
+			$ishObjects[0].IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0].IshType" {
-			$ishObjects[0].IshType | Should Not BeNullOrEmpty
+			$ishObjects[0].IshType | Should -Not -BeNullOrEmpty
 		}
-		# Double check following 3 ReferenceType enum usage 
+		
 		It "ishObjects[0].ObjectRef" {
-			$ishObjects[0].ObjectRef | Should Not BeNullOrEmpty
-		}
-		It "ishObjects[0].VersionRef" {
-			$ishObjects[0].VersionRef | Should Not BeNullOrEmpty
-		}
-		It "ishObjects[0].LngRef" {
-			$ishObjects[0].LngRef | Should Not BeNullOrEmpty
+			# Double check following 3 ReferenceType enum usage 
+			$ishObjects[0].ObjectRef | Should -Not -BeNullOrEmpty
+			$ishObjects[0].VersionRef | Should -Not -BeNullOrEmpty
+			$ishObjects[0].LngRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjects[0] ConvertTo-Json" {
-			(ConvertTo-Json $ishObjects[0]).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishObjects[0]).Length -gt 2 | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObjects[0].ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObjects[0].ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObjects[0].version_version_value.Length -ge 1 | Should Be $true 
+			$ishObjects[0].version_version_value.Length -ge 1 | Should -Be $true 
 			#language
-			$ishObjects[0].fstatus.Length -ge 1 | Should Be $true 
-			$ishObjects[0].fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true 
-			$ishObjects[0].fishstatustype -ge 0 | Should Be $true
+			$ishObjects[0].fstatus.Length -ge 1 | Should -Be $true 
+			$ishObjects[0].fstatus_lng_element.StartsWith('VSTATUS') | Should -Be $true 
+			$ishObjects[0].fishstatustype -ge 0 | Should -Be $true
         }
         It "ishObjects[0].version_version_value" { 
             # First version
-            ($ishobjects | Where-Object version_version_value -eq 1 | Select-Object).Length | Should BeExactly $ishTopicCount 
+            ($ishobjects | Where-Object version_version_value -eq 1 | Select-Object).Length | Should -BeExactly $ishTopicCount 
             # Second version
-            ($ishobjects | Where-Object version_version_value -eq 2 | Select-Object).Length | Should BeExactly $ishTopicCount 
+            ($ishobjects | Where-Object version_version_value -eq 2 | Select-Object).Length | Should -BeExactly $ishTopicCount 
 		}
 	}
-
-	Context “Get-IshFolderContent BaseFolderGroup" {
+	Context "Get-IshFolderContent BaseFolderGroup" {
 		It "Parameter BaseFolder invalid" {
-			{ Get-IshFolderContent -IShSession $ishSession -BaseFolder None } | Should Throw
+			{ Get-IshFolderContent -IShSession $ishSession -BaseFolder None } | Should -Throw
 		}
 		It "Parameter BaseFolder Data" {
-			(Get-IshFolderContent -IShSession $ishSession -BaseFolder Data).Count -eq 0 | Should Be $true
+			(Get-IshFolderContent -IShSession $ishSession -BaseFolder Data).Count -eq 0 | Should -Be $true
 		}
 		It "Parameter BaseFolder System" {
-			(Get-IshFolderContent -IShSession $ishSession -BaseFolder System).Count -eq 0 | Should Be $true
+			(Get-IshFolderContent -IShSession $ishSession -BaseFolder System).Count -eq 0 | Should -Be $true
 		}
 		It "Parameter BaseFolder Favorites" {
-			{ Get-IshFolderContent -IShSession $ishSession -BaseFolder Favorites } | Should Not Throw
+			{ Get-IshFolderContent -IShSession $ishSession -BaseFolder Favorites } | Should -Not -Throw
 		}
 		It "Parameter BaseFolder EditorTemplate" {
-			(Get-IshFolderContent -IShSession $ishSession -BaseFolder EditorTemplate).Count -eq 0 | Should Be $true
+			(Get-IshFolderContent -IShSession $ishSession -BaseFolder EditorTemplate).Count -eq 0 | Should -Be $true
 		}
 	}
-
-	Context “Get-IshFolderContent FolderPathGroup" {
+	Context "Get-IshFolderContent FolderPathGroup" {
 		It "Parameter FolderPath invalid" {
-			{ Get-IshFolderContent -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should Throw "-102001"
+			$exception = { Get-IshFolderContent -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-102001] The folder 'INVALIDFOLDERPATH' does not exist. [name:"'INVALIDFOLDERPATH'"] [102001;InvalidObject]
+			$exception -like "*102001*" | Should -Be $true 
+			$exception -like "*InvalidObject*" | Should -Be $true
 		}
 		It "Parameter FolderPath $folderTestRootPath" {
-			(Get-IshFolderContent -IshSession $ishSession -FolderPath $folderTestRootPath).Count -ge 0 | Should Be $true
+			(Get-IshFolderContent -IshSession $ishSession -FolderPath $folderTestRootPath).Count -ge 0 | Should -Be $true
 		}
 		It "Parameter FolderPath Topic" {
 			$folderPath = Get-IshFolderLocation -IshSession $ishSession -IshFolder $ishFolderTopic
-			(Get-IshFolderContent -IshSession $ishSession -FolderPath $folderPath).Count | Should Be $ishTopicCount
+			(Get-IshFolderContent -IshSession $ishSession -FolderPath $folderPath).Count | Should -Be $ishTopicCount
 		}
 	}
-
-	Context “Get-IshFolderContent FolderIdsGroup" {
-		[long]$ishFolderDataFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef
-		[long]$ishFolderSystemFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef
-		[long]$ishFolderFavoritesFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef
-		[long]$ishFolderEditorTemplateFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef
+	Context "Get-IshFolderContent FolderIdsGroup" {
+		BeforeAll {
+			[long]$ishFolderDataFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef
+			[long]$ishFolderSystemFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef
+			[long]$ishFolderFavoritesFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef
+			[long]$ishFolderEditorTemplateFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef
+		}
 		It "Parameter FolderId invalid" {
-			{ Get-IshFolderContent -IShSession $ishSession -FolderId "INVALIDFOLDERID" } | Should Throw
+			{ Get-IshFolderContent -IShSession $ishSession -FolderId "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter FolderId from System" {
-			(Get-IshFolderContent -IshSession $ishSession -FolderId $ishFolderSystemFolderRef).Count -eq 0 | Should Be $true
+			(Get-IshFolderContent -IshSession $ishSession -FolderId $ishFolderSystemFolderRef).Count -eq 0 | Should -Be $true
 		}
 		<# FolderId[] ValueFromPipeline is not implemented
 		It "Pipeline FolderId" {
 			$ishObjects = @($ishFolderDataFolderRef,$ishFolderSystemFolderRef,$ishFolderFavoritesFolderRef,$ishFolderEditorTemplateFolderRef) | Get-IshFolderContent -IshSession $ishSession
-			$ishObjects.Count -ge 0 | Should Be $true
+			$ishObjects.Count -ge 0 | Should -Be $true
 		}
 		It "Pipeline FolderId MetadataBatchSize[1]" {
 			$ishSession.MetadataBatchSize = 1
 			$ishObjects = @($ishFolderDataFolderRef,$ishFolderSystemFolderRef,$ishFolderFavoritesFolderRef,$ishFolderEditorTemplateFolderRef) | Get-IshFolderContent -IshSession $ishSession
-			$ishObjects.Count -ge 0 | Should Be $true
+			$ishObjects.Count -ge 0 | Should -Be $true
 		}
 		#>
 	}
-
-	Context “Get-IshFolderContent IshFoldersGroup" {
-		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
-		$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
+	Context "Get-IshFolderContent IshFoldersGroup" {
+		BeforeAll {
+			$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
+			$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
+		}
 		It "Parameter IshFolder invalid" {
-			{ Get-IshFolderContent -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should Throw
+			{ Get-IshFolderContent -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter IshFolder Single with implicit IshSession" {
-			(Get-IshFolderContent -IshFolder $ishFolderSystem).Count -eq 0 | Should Be $true
+			(Get-IshFolderContent -IshFolder $ishFolderSystem).Count -eq 0 | Should -Be $true
 		}
 		It "Parameter IshFolder Multiple with implicit IshSession" {
 			$ishObjects = Get-IshFolderContent -IshFolder @($ishFolderData,$ishFolderSystem)
-			$ishObjects.Count -eq 0| Should Be $true
+			$ishObjects.Count -eq 0| Should -Be $true
 		}
 		It "Pipeline IshFolder Single" {
 			$ishObjects = $ishFolderData | Get-IshFolderContent -IshSession $ishSession
-			$ishObjects.Count -eq 0 | Should Be $true
+			$ishObjects.Count -eq 0 | Should -Be $true
 		}
 		It "Pipeline IshFolder Multiple" {
 			$ishObjects = @($ishFolderData,$ishFolderSystem) | Get-IshFolderContent -IshSession $ishSession
-			$ishObjects.Count -eq 0| Should Be $true
+			$ishObjects.Count -eq 0| Should -Be $true
 		}
 	}
-
-	Context “Get-IshFolderContent IshFoldersGroup mixing MetadataFilter and VersionFilter/LanguagesFilter" {
-		$ishDocumentObjsVersionOne = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -VersionFilter 1 -LanguagesFilter ($ishLng,$ishLngTarget1)
-		$ishDocumentObjsVersionLatest = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -VersionFilter LATEST -LanguagesFilter ($ishLng,$ishLngTarget1)
-		$ishDocumentObjsAllLanguages = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic 
-		$ishDocumentObjsExplicitLanguage = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng
-		$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name FSTATUS -ValueType Element -FilterOperator Equal -Value $ishStatusDraft
-		$ishDocumentObjsExplicitLanguageAndStatus = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
-		$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name FSTATUS -ValueType Element -FilterOperator NotEqual -Value $ishStatusDraft
-		$ishDocumentObjsExplicitLanguageAndWrongStatus = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
-		$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name DOC-LANGUAGE -ValueType Element -FilterOperator In -Value $ishLng
-		$ishDocumentObjsExplicitLanguageAndLanguage = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
-		$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name DOC-LANGUAGE -ValueType Element -FilterOperator NotEqual -Value $ishLng
-		$ishDocumentObjsLanguageFilterOverridesMetadatafilter = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
+	Context "Get-IshFolderContent IshFoldersGroup mixing MetadataFilter and VersionFilter/LanguagesFilter" {
+		BeforeAll {
+			$ishDocumentObjsVersionOne = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -VersionFilter 1 -LanguagesFilter ($ishLng,$ishLngTarget1)
+			$ishDocumentObjsVersionLatest = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -VersionFilter LATEST -LanguagesFilter ($ishLng,$ishLngTarget1)
+			$ishDocumentObjsAllLanguages = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic 
+			$ishDocumentObjsExplicitLanguage = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng
+			$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name FSTATUS -ValueType Element -FilterOperator Equal -Value $ishStatusDraft
+			$ishDocumentObjsExplicitLanguageAndStatus = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
+			$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name FSTATUS -ValueType Element -FilterOperator NotEqual -Value $ishStatusDraft
+			$ishDocumentObjsExplicitLanguageAndWrongStatus = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
+			$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name DOC-LANGUAGE -ValueType Element -FilterOperator In -Value $ishLng
+			$ishDocumentObjsExplicitLanguageAndLanguage = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
+			$metadataFilter = Set-IshMetadataFilterField -IshSession $ishSession -Level Lng -Name DOC-LANGUAGE -ValueType Element -FilterOperator NotEqual -Value $ishLng
+			$ishDocumentObjsLanguageFilterOverridesMetadatafilter = Get-IshFolderContent -IshSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter $ishLng -MetadataFilter $metadataFilter
+		}
 		It "Parameter VersionFilter" {
-			$ishDocumentObjsVersionOne.Count | Should Be $ishTopicCount
-			$ishDocumentObjsVersionLatest.Count | Should Be $ishTopicCount
-			$ishDocumentObjsVersionOne.Count -eq $ishDocumentObjsVersionLatest.Count | Should Be $true
+			$ishDocumentObjsVersionOne.Count | Should -Be $ishTopicCount
+			$ishDocumentObjsVersionLatest.Count | Should -Be $ishTopicCount
+			$ishDocumentObjsVersionOne.Count -eq $ishDocumentObjsVersionLatest.Count | Should -Be $true
 		}
 		It "Parameter LanguagesFilter" {
-			$ishDocumentObjsAllLanguages.Count | Should Be $ishTopicCount
-			$ishDocumentObjsExplicitLanguage.Count | Should Be $ishTopicCount
-			$ishDocumentObjsAllLanguages.Count -eq $ishDocumentObjsExplicitLanguage.Count | Should Be $true
+			$ishDocumentObjsAllLanguages.Count | Should -Be $ishTopicCount
+			$ishDocumentObjsExplicitLanguage.Count | Should -Be $ishTopicCount
+			$ishDocumentObjsAllLanguages.Count -eq $ishDocumentObjsExplicitLanguage.Count | Should -Be $true
 		}
 		It "Parameter LanguagesFilter and matching status MetadataFilter" {
-			$ishDocumentObjsExplicitLanguageAndStatus.Count -eq $ishDocumentObjsExplicitLanguage.Count | Should Be $true
+			$ishDocumentObjsExplicitLanguageAndStatus.Count -eq $ishDocumentObjsExplicitLanguage.Count | Should -Be $true
 		}
 		It "Parameter LanguagesFilter and non-matching status MetadataFilter" {
-			$ishDocumentObjsExplicitLanguageAndWrong.Count | Should Be 0
+			$ishDocumentObjsExplicitLanguageAndWrong.Count | Should -Be 0
 		}
 		It "Parameter LanguagesFilter and matching language MetadataFilter" {
-			$ishDocumentObjsExplicitLanguageAndLanguage.Count | Should Be $ishTopicCount
+			$ishDocumentObjsExplicitLanguageAndLanguage.Count | Should -Be $ishTopicCount
 		}
 		It "Parameter LanguagesFilter overrides MetadataFilter (non-matching language filter)" {
-			$ishDocumentObjsLanguageFilterOverridesMetadatafilter.Count | Should Be 3
+			$ishDocumentObjsLanguageFilterOverridesMetadatafilter.Count | Should -Be 3
 		}
 	}
 	Context "Get-IshFolderContent use LanguagesFilter" {
 		It "LanguagesFilter on '$ishLngLabel' language" {
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter "$ishLngLabel"  # en
-			$ishObjects.Count | Should Be $ishTopicCount
+			$ishObjects.Count | Should -Be $ishTopicCount
 		}
 		It "LanguagesFilter on '$ishLngTarget2Label, $ishLngLabel' languages" {
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter @("$ishLngTarget2Label", "$ishLngLabel")  # de, en
-			$ishObjects.Count | Should Be $ishTopicCount
+			$ishObjects.Count | Should -Be $ishTopicCount
 		}
 		It "LanguagesFilter on '$ishLngTarget1Label' language (filtering out results)" {
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -LanguagesFilter @("$ishLngTarget1Label")  # es
-			$ishObjects.Count | Should Be 0
+			$ishObjects.Count | Should -Be 0
 		}
 		It "LanguagesFilter overrides MetadataFilter" {
 			$metadataFilter = Set-IshMetadataFilterField -Name "DOC-LANGUAGE" -Level Lng -Value "$ishLngTarget1Label" -ValueType Value  # es
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -MetadataFilter $metadataFilter -LanguagesFilter @("$ishLngTarget2Label", "$ishLngLabel")  # de, en
-			$ishObjects.Count | Should Be $ishTopicCount
+			$ishObjects.Count | Should -Be $ishTopicCount
 		}
 	}
-	
 	Context "Get-IshFolderContent use MetadataFilter" {
 		It "Metadata filter on FSTATUS" {
 			$metadataFilter = Set-IshMetadataFilterField -Name "FSTATUS" -Level Lng -Value $ishStatusDraft -ValueType Element
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -MetadataFilter $metadataFilter
-			$ishObjects.Count | Should Be $ishTopicCount
+			$ishObjects.Count | Should -Be $ishTopicCount
 		}
-		
 		It "Metadata filter on FSTATUS (filtering out results)" {
 			$metadataFilter = Set-IshMetadataFilterField -Name "FSTATUS" -Level Lng -Value $ishStatusReleased -ValueType Element
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -MetadataFilter $metadataFilter
-			$ishObjects.Count | Should Be 0
+			$ishObjects.Count | Should -Be 0
 		}
-		
 		It "Metadata filter on FSTATUS,DOC-LANGUAGE" {
 			$metadataFilter = Set-IshMetadataFilterField -Name "FSTATUS" -Level Lng -Value $ishStatusDraft -ValueType Element |
 							  Set-IshMetadataFilterField -Name "DOC-LANGUAGE" -Level Lng -Value "$ishLngLabel" -ValueType Value  # en
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -MetadataFilter $metadataFilter
-			$ishObjects.Count | Should Be $ishTopicCount
+			$ishObjects.Count | Should -Be $ishTopicCount
 		}
 		It "Metadata filter on (FSTATUS, DOC-LANGUAGE) with LanguagesFilter override" {
 			$metadataFilter = Set-IshMetadataFilterField -Name "FSTATUS" -Level Lng -Value $ishStatusDraft -ValueType Element |
 							  Set-IshMetadataFilterField -Name "DOC-LANGUAGE" -Level Lng -Value "$ishLngLabel" -ValueType Value  # en
 			$ishObjects = Get-IshFolderContent -IShSession $ishSession -IshFolder $ishFolderTopic -MetadataFilter $metadataFilter -LanguagesFilter @("$ishLngTarget2Label", "$ishLngTarget1Label")  # de, es
-			$ishObjects.Count | Should Be 0
+			$ishObjects.Count | Should -Be 0
 		}		
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession -VersionFilter "" | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderLocation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderLocation.Tests.ps1
@@ -1,107 +1,113 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshFolderLocation"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshFolderLocation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshFolderLocation" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	Context “Get-IshFolderLocation ParameterGroup" {
+Describe "Get-IshFolderLocation" -Tags "Read" {
+	Context "Get-IshFolderLocation ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshFolderLocation -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Get-IshFolderLocation -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshFolderLocation returns string object" {
-		$ishObjects = Get-IshFolderLocation -IShSession $ishSession -BaseFolder Data
 		It "GetType().Name" {
-			$ishObjects.GetType().Name | Should BeExactly "String"
+			$ishObjects = Get-IshFolderLocation -IShSession $ishSession -BaseFolder Data
+			$ishObjects.GetType().Name | Should -BeExactly "String"
 		}
 	}
-
-	Context “Get-IshFolderLocation BaseFolderGroup" {
+	Context "Get-IshFolderLocation BaseFolderGroup" {
 		It "Parameter BaseFolder invalid" {
-			{ Get-IshFolderLocation -IShSession $ishSession -BaseFolder None } | Should Throw
+			{ Get-IshFolderLocation -IShSession $ishSession -BaseFolder None } | Should -Throw
 		}
 		It "Parameter BaseFolder Data" {
-			Get-IshFolderLocation -IShSession $ishSession -BaseFolder Data | Should Not BeNullOrEmpty
+			Get-IshFolderLocation -IShSession $ishSession -BaseFolder Data | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter BaseFolder System" {
-			Get-IshFolderLocation -IShSession $ishSession -BaseFolder System | Should Not BeNullOrEmpty
+			Get-IshFolderLocation -IShSession $ishSession -BaseFolder System | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter BaseFolder Favorites" {
-			Get-IshFolderLocation -IShSession $ishSession -BaseFolder Favorites | Should Not BeNullOrEmpty
+			Get-IshFolderLocation -IShSession $ishSession -BaseFolder Favorites | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter BaseFolder EditorTemplate" {
-			Get-IshFolderLocation -IShSession $ishSession -BaseFolder EditorTemplate | Should Not BeNullOrEmpty
+			Get-IshFolderLocation -IShSession $ishSession -BaseFolder EditorTemplate | Should -Not -BeNullOrEmpty
 		}
 	}
-
-	Context “Get-IshFolderLocation FolderPathGroup" {
+	Context "Get-IshFolderLocation FolderPathGroup" {
 		It "Parameter FolderPath invalid" {
-			{ Get-IshFolderLocation -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should Throw "-102001"
+			$exception = { Get-IshFolderLocation -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-102001] The folder 'INVALIDFOLDERPATH' does not exist. [name:"'INVALIDFOLDERPATH'"] [102001;InvalidObject]
+			$exception -like "*102001*" | Should -Be $true 
+			$exception -like "*InvalidObject*" | Should -Be $true
 		}
 		It "Parameter FolderPath $folderTestRootPath" {
-			Get-IshFolderLocation -IshSession $ishSession -FolderPath $folderTestRootPath | Should Be $folderTestRootPath
+			Get-IshFolderLocation -IshSession $ishSession -FolderPath $folderTestRootPath | Should -Be $folderTestRootPath
 		}
 	}
-
-	Context “Get-IshFolderLocation FolderIdsGroup" {
-		[long]$ishFolderDataFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef
-		[long]$ishFolderSystemFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef
-		[long]$ishFolderFavoritesFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef
-		[long]$ishFolderEditorTemplateFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef
+	Context "Get-IshFolderLocation FolderIdsGroup" {
+		BeforeAll {
+			[long]$ishFolderDataFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Data).IshFolderRef
+			[long]$ishFolderSystemFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder System).IshFolderRef
+			[long]$ishFolderFavoritesFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder Favorites).IshFolderRef
+			[long]$ishFolderEditorTemplateFolderRef = (Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate).IshFolderRef
+		}
 		It "Parameter FolderId invalid" {
-			{ Get-IshFolderLocation -IShSession $ishSession -FolderId "INVALIDFOLDERID" } | Should Throw
+			{ Get-IshFolderLocation -IShSession $ishSession -FolderId "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter FolderId from EditorTemplate" {
-			Get-IshFolderLocation -IshSession $ishSession -FolderId $ishFolderEditorTemplateFolderRef | Should Not BeNullOrEmpty
+			Get-IshFolderLocation -IshSession $ishSession -FolderId $ishFolderEditorTemplateFolderRef | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter FolderId 0 no longer returns BaseFolder" {
-			{ Get-IshFolderLocation -FolderId 0 } | Should Throw "-105001"
+			$exception = { Get-IshFolderLocation -FolderId 0 } | Should -Throw -PassThru
+			# 14.0.4 message is:  [-105001] The parameter folderRef with value "0" is invalid. Zero is not allowed as valid value. [105001;InvalidParameter]
+			$exception -like "*105001*" | Should -Be $true 
+			$exception -like "*InvalidParameter*" | Should -Be $true
 		}
 		It "Pipeline FolderId" {
 			$ishObjects = @($ishFolderDataFolderRef,$ishFolderSystemFolderRef,$ishFolderFavoritesFolderRef,$ishFolderEditorTemplateFolderRef) | Get-IshFolderLocation -IshSession $ishSession
-			$ishObjects.Count | Should Be 4
+			$ishObjects.Count | Should -Be 4
 		}
 		It "Pipeline FolderId MetadataBatchSize[1]" {
 			$ishSession.MetadataBatchSize = 1
 			$ishObjects = @($ishFolderDataFolderRef,$ishFolderSystemFolderRef,$ishFolderFavoritesFolderRef,$ishFolderEditorTemplateFolderRef) | Get-IshFolderLocation -IshSession $ishSession
-			$ishObjects.Count | Should Be 4
+			$ishObjects.Count | Should -Be 4
 		}
 	}
-
-	Context “Get-IshFolderLocation IshFoldersGroup" {
-		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
-		$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
-		$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
-		$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+	Context "Get-IshFolderLocation IshFoldersGroup" {
+		BeforeAll {
+			$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
+			$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
+			$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
+			$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+		}
 		It "Parameter IshFolder invalid" {
-			{ Get-IshFolderLocation -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should Throw
+			{ Get-IshFolderLocation -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter IshFolder Single with implicit IshSession" {
 			$ishObjects = Get-IshFolderLocation -IshFolder $ishFolderEditorTemplate
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshFolder Multiple with implicit IshSession" {
 			$ishObjects = Get-IshFolderLocation -IshFolder @($ishFolderData,$ishFolderSystem)
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshFolder Single" {
 			$ishObjects = @($ishFolderData) | Get-IshFolderLocation -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshFolder Multiple" {
 			$ishObjects = @($ishFolderData,$ishFolderSystem,$ishFolderFavorites,$ishFolderEditorTemplate) | Get-IshFolderLocation -IshSession $ishSession
-			$ishObjects.Count | Should Be 4
+			$ishObjects.Count | Should -Be 4
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/MoveIshFolder.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/MoveIshFolder.Tests.ps1
@@ -1,9 +1,9 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Move-IshFolder"
-try {
+BeforeAll {
+	$cmdletName = "Move-IshFolder"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Write-Host "Initializing Test Data and Variables"
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
 	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
 	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
 	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
@@ -24,64 +24,63 @@ Write-Host "Initializing Test Data and Variables"
 	$ishFolderF = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderF" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 	$ishFolderG = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderG" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 	$ishFolderH = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderH" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+}
 
-Describe “Move-IshFolder" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-
-	Context “Move-IshFolder ParameterGroup" {
+Describe "Move-IshFolder" -Tags "Create" {
+	Context "Move-IshFolder ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Move-IshFolder -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Move-IshFolder -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 	}
-
 	Context "Move-IshFolder returns IshFolder object" {
-		$ishFolderData = Move-IshFolder -IShSession $ishSession -FolderId $ishFolderB.IshFolderRef -ToFolderId $ishFolderA.IshFolderRef
+		BeforeAll {
+			$ishFolderData = Move-IshFolder -IShSession $ishSession -FolderId $ishFolderB.IshFolderRef -ToFolderId $ishFolderA.IshFolderRef
+		}
 		It "GetType().Name" {
-			$ishFolderData.GetType().Name | Should BeExactly "IshFolder"
+			$ishFolderData.GetType().Name | Should -BeExactly "IshFolder"
 		}
 		It "$ishFolderData.IshFolderRef" {
-			$ishFolderData.IshFolderRef -eq $ishFolderB.IshFolderRef | Should Be $true
+			$ishFolderData.IshFolderRef -eq $ishFolderB.IshFolderRef | Should -Be $true
 		}
 		It "$ishFolderData.IshFolderType" {
-			$ishFolderData.IshFolderType | Should Not BeNullOrEmpty
+			$ishFolderData.IshFolderType | Should -Not -BeNullOrEmpty
 		}
 		It "$ishFolderData.IshField" {
-			$ishFolderData.IshField | Should Not BeNullOrEmpty
+			$ishFolderData.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishFolderData.name.Length -ge 1 | Should Be $true 
-			$ishFolderData.fdocumenttype.Length -ge 1 | Should Be $true 
-			$ishFolderData.fdocumenttype_none_element.StartsWith('VDOCTYPE') | Should Be $true 
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishFolderData.name.Length -ge 1 | Should -Be $true 
+			$ishFolderData.fdocumenttype.Length -ge 1 | Should -Be $true 
+			$ishFolderData.fdocumenttype_none_element.StartsWith('VDOCTYPE') | Should -Be $true 
 		}
 	}
-
-	Context “Move-IshFolder IshFoldersGroup" {
+	Context "Move-IshFolder IshFoldersGroup" {
 		It "Parameter IshFolder invalid" {
-			{ Move-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" -ToFolderId $ishFolderA.IshFolderRef } | Should Throw
+			{ Move-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" -ToFolderId $ishFolderA.IshFolderRef } | Should -Throw
 		}
 		It "Parameter IshFolder Single with implicit IshSession" {
 			$ishFolders = Move-IshFolder -IshFolder $ishFolderC -ToFolderId $ishFolderA.IshFolderRef
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Parameter IshFolder Multiple with implicit IshSession" {
 			$ishFolders = Move-IshFolder -IshFolder @($ishFolderD,$ishFolderE) -ToFolderId $ishFolderA.IshFolderRef
-			$ishFolders.Count | Should Be 2
+			$ishFolders.Count | Should -Be 2
 		}
 		It "Pipeline IshFolder Single" {
 			$ishFolders = $ishFolderF | Move-IshFolder -IshSession $ishSession -ToFolderId $ishFolderA.IshFolderRef
-			$ishFolders.Count | Should Be 1
+			$ishFolders.Count | Should -Be 1
 		}
 		It "Pipeline IshFolder Multiple" {
 			$ishFolders = @($ishFolderG,$ishFolderH) | Move-IshFolder -IshSession $ishSession -ToFolderId $ishFolderA.IshFolderRef
-			$ishFolders.Count | Should Be 2
+			$ishFolders.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/RemoveIshFolder.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/RemoveIshFolder.Tests.ps1
@@ -1,94 +1,96 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Remove-IshFolder"
-try {
+BeforeAll {
+	$cmdletName = "Remove-IshFolder"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Remove-IshFolder" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderFolderIdGroup = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderIdGroup" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderFolderPathGroup = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderPathGroup" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderIshFoldersGroup = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroup" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderIshFoldersGroupA = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupA" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderIshFoldersGroupB = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupB" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderIshFoldersGroupC = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupC" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderIshFoldersGroupD = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupD" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderAllYourBase = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "All" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderAllYourBase.IshFolderRef)       -FolderType ISHModule -FolderName "Your" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Base" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Belong" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "To" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Us!" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Remove-IshFolder" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	Context “Remove-IshFolder FolderIdGroup" {
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderFolderIdGroup = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderIdGroup" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderFolderPathGroup = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "FolderPathGroup" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderIshFoldersGroup = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroup" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderIshFoldersGroupA = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupA" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderIshFoldersGroupB = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupB" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderIshFoldersGroupC = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupC" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderIshFoldersGroupD = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "IshFoldersGroupD" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderAllYourBase = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "All" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolderAllYourBase.IshFolderRef)       -FolderType ISHModule -FolderName "Your" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Base" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Belong" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "To" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolder = Add-IshFolder -IshSession $ishSession -ParentFolderId ($ishFolder.IshFolderRef)       -FolderType ISHModule -FolderName "Us!" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+	}
+	Context "Remove-IshFolder FolderIdGroup" {
 		It "Parameter IshSession invalid" {
-			{ Remove-IshFolder -IShSession "INVALIDISHSESSION" -FolderId "-7" } | Should Throw
+			{ Remove-IshFolder -IShSession "INVALIDISHSESSION" -FolderId "-7" } | Should -Throw
 		}
 		It "Parameter FolderId 0" {
-			{ Remove-IshFolder -IShSession $ishSession -FolderId 0 } | Should Not Throw
+			{ Remove-IshFolder -IShSession $ishSession -FolderId 0 } | Should -Not -Throw
 		}
 		It "Parameter FolderId \General\" {
-			{ Remove-IshFolder -IShSession $ishSession -FolderId (Get-IshFolder -IshSession $ishSession -BaseFolder Data).IshFolderRef } | Should Throw
+			{ Remove-IshFolder -IShSession $ishSession -FolderId (Get-IshFolder -IshSession $ishSession -BaseFolder Data).IshFolderRef } | Should -Throw
 		}
 		It "Remove-IshFolder returns nothing" {
 			$ishFolder = Remove-IshFolder -IshSession $ishSession -FolderId $ishFolderFolderIdGroup.IshFolderRef 
-			$ishFolder -eq $null | Should Be $true
+			$ishFolder -eq $null | Should -Be $true
 		}
 	}
-
-	Context “Remove-IshFolder FolderPathGroup" {
+	Context "Remove-IshFolder FolderPathGroup" {
 		It "Parameter FolderPathGroup invalid" {
-			{ Remove-IshFolder -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should Throw
+			{ Remove-IshFolder -IShSession $ishSession -FolderPath "INVALIDFOLDERPATH" } | Should -Throw
 		}
 		It "Parameter FolderPathGroup FolderPathGroup" {
-			{ Remove-IshFolder -IShSession $ishSession -FolderPath ($folderTestRootPath + $ishSession.FolderPathSeparator + $cmdletName + $ishSession.FolderPathSeparator +  "FolderPathGroup") } | Should Not Throw
+			{ Remove-IshFolder -IShSession $ishSession -FolderPath ($folderTestRootPath + $ishSession.FolderPathSeparator + $cmdletName + $ishSession.FolderPathSeparator +  "FolderPathGroup") } | Should -Not -Throw
 		}
 	}
-
-	Context “Remove-IshFolder IshFoldersGroup" {
-		$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
-		$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
-		$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
-		$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+	Context "Remove-IshFolder IshFoldersGroup" {
+		BeforeAll {
+			$ishFolderData = Get-IshFolder -IShSession $ishSession -BaseFolder Data
+			$ishFolderSystem = Get-IshFolder -IShSession $ishSession -BaseFolder System
+			$ishFolderFavorites = Get-IshFolder -IShSession $ishSession -BaseFolder Favorites
+			$ishFolderEditorTemplate = Get-IshFolder -IShSession $ishSession -BaseFolder EditorTemplate
+		}
 		It "Parameter IshFolder invalid" {
-			{ Remove-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should Throw
+			{ Remove-IshFolder -IShSession $ishSession -IshFolder "INVALIDFOLDERID" } | Should -Throw
 		}
 		It "Parameter IshFolder Single with implicit IshSession" {
-			{ Remove-IshFolder -IshFolder $ishFolderIshFoldersGroup } | Should Not Throw
+			{ Remove-IshFolder -IshFolder $ishFolderIshFoldersGroup } | Should -Not -Throw
 		}
 		It "Parameter IshFolder Multiple with implicit IshSession" {
-			{ Remove-IshFolder -IshFolder @($ishFolderIshFoldersGroupA,$ishFolderIshFoldersGroupB) } | Should Not Throw
+			{ Remove-IshFolder -IshFolder @($ishFolderIshFoldersGroupA,$ishFolderIshFoldersGroupB) } | Should -Not -Throw
 		}
 		It "Pipeline IshFolder" {
-			{  @($ishFolderData,$ishFolderSystem,$ishFolderFavorites) | Remove-IshFolder -IshSession $ishSession } | Should Throw
+			{  @($ishFolderData,$ishFolderSystem,$ishFolderFavorites) | Remove-IshFolder -IshSession $ishSession } | Should -Throw
 		}
 		It "Pipeline IshFolder Multiple" {
-			{  @($ishFolderIshFoldersGroupC,$ishFolderIshFoldersGroupD) | Remove-IshFolder -IshSession $ishSession } | Should Not Throw
+			{  @($ishFolderIshFoldersGroupC,$ishFolderIshFoldersGroupD) | Remove-IshFolder -IshSession $ishSession } | Should -Not -Throw
 		}
 	}
-
 	Context "Remove-IshFolder Recurse" {
 		It "Parameter FolderIdGroup" {
 			$ishFolder = Remove-IshFolder -IshSession $ishSession -FolderId $ishFolderAllYourBase.IshFolderRef -Recurse
-			$ishFolder -eq $null | Should Be $true
+			$ishFolder -eq $null | Should -Be $true
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/ListOfValues/AddIshLovValue.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/ListOfValues/AddIshLovValue.Tests.ps1
@@ -1,85 +1,87 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshLovValue"
-try {
-	
-Describe “Add-IshLovValue" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
+BeforeAll {
+	$cmdletName = "Add-IshLovValue"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-	Context “Add-IshLovValue ParameterGroup" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+	
+Describe "Add-IshLovValue" -Tags "Create" {
+	Context "Add-IshLovValue ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshLovValue -IShSession "INVALIDISHSESSION" -LovId $ishLovId -Label "ISHRemote $ishLovId Entry" -Description "ISHRemote $ishLovId Entry Description" -IshLovValue "ISHREMOTE$ishLovId" } | Should Throw
+			{ Add-IshLovValue -IShSession "INVALIDISHSESSION" -LovId $ishLovId -Label "ISHRemote $ishLovId Entry" -Description "ISHRemote $ishLovId Entry Description" -IshLovValue "ISHREMOTE$ishLovId" } | Should -Throw
 		}
 	}
-
 	Context "Add-IshLovValue returns IshLovValue object" {
-		$timestamp = Get-Date -Format "yyyyMMddHHmmssfff"
-		$label = "ISHRemote $ishLovId Entry $timestamp"
-		$description = "ISHRemote::$ishLovId Entry $timestamp Description"
-		$lovValueId = ("ISHREMOTE"+$ishLovId+$timestamp)
-		$ishLovValue = Add-IshLovValue -IShSession $ishSession -LovId $ishLovId -Label $label -Description $description -LovValueId $lovValueId
+		BeforeAll {
+			$timestamp = Get-Date -Format "yyyyMMddHHmmssfff"
+			$label = "ISHRemote $ishLovId Entry $timestamp"
+			$description = "ISHRemote::$ishLovId Entry $timestamp Description"
+			$lovValueId = ("ISHREMOTE"+$ishLovId+$timestamp)
+			$ishLovValue = Add-IshLovValue -IShSession $ishSession -LovId $ishLovId -Label $label -Description $description -LovValueId $lovValueId
+		}
 		It "GetType().Name" {
-			$ishLovValue.GetType().Name | Should BeExactly "IshLovValue"
+			$ishLovValue.GetType().Name | Should -BeExactly "IshLovValue"
 		}
 		It "ishLovValue.IshLovValueRef" {
-			$ishLovValue.IshLovValueRef -ge 0 | Should Be $true
+			$ishLovValue.IshLovValueRef -ge 0 | Should -Be $true
 		}
 		It "ishLovValue.LovId" {
-			$ishLovValue.LovId | Should Be "$ishLovId"
+			$ishLovValue.LovId | Should -Be "$ishLovId"
 		}
 		It "ishLovValue.IshRef" {
-			$ishLovValue.IshRef | Should be $lovValueId
+			$ishLovValue.IshRef | Should -Be $lovValueId
 		}
 		It "ishLovValue.Label" {
-			$ishLovValue.Label | Should Be $label
+			$ishLovValue.Label | Should -Be $label
 		}
 		It "ishLovValue.Description" {
-			$ishLovValue.Description | Should Be $description
+			$ishLovValue.Description | Should -Be $description
 		}
 		It "ishLovValue.Active" {
-			$ishLovValue.Active | Should Be $True
+			$ishLovValue.Active | Should -Be $True
 		}
 	}
-
-	Context “Add-IshLovValue IshLovValueGroup" {
-		$timestamp = Get-Date -Format "yyyyMMddHHmmssfff"
-		$label = "ISHRemote $ishLovId Entry $timestamp"
-		$description = "ISHRemote::$ishLovId Entry $timestamp Description"
-		$lovValueId = ("ISHREMOTE"+$ishLovId+$timestamp)
-		$ishLovValue = Add-IshLovValue -IShSession $ishSession -LovId $ishLovId -Label $label -Description $description -LovValueId $lovValueId
+	Context "Add-IshLovValue IshLovValueGroup" {
+		BeforeAll {
+			$timestamp = Get-Date -Format "yyyyMMddHHmmssfff"
+			$label = "ISHRemote $ishLovId Entry $timestamp"
+			$description = "ISHRemote::$ishLovId Entry $timestamp Description"
+			$lovValueId = ("ISHREMOTE"+$ishLovId+$timestamp)
+			$ishLovValue = Add-IshLovValue -IShSession $ishSession -LovId $ishLovId -Label $label -Description $description -LovValueId $lovValueId
+		}
 		It "Parameter IshLovValue invalid" {
-			{ Add-IshLovValue -IShSession $ishSession -IshLovValue "INVALIDLOVVALUE" } | Should Throw
+			{ Add-IshLovValue -IShSession $ishSession -IshLovValue "INVALIDLOVVALUE" } | Should -Throw
 		}
 		It "Parameter IshLovValue Single with optional IshSession" {
 			Remove-IshLovValue -LovId $ishLovId -LovValueId $lovValueId
 			$ishLovValues = Add-IshLovValue -IshLovValue $ishLovValue
-			$ishLovValues.Count | Should Be 1
+			$ishLovValues.Count | Should -Be 1
 		}
 		<# NotImplemented
 		It "Parameter IshLovValue Multiple" {
 			$ishFolderEditorTemplate.IshField = $ishFolderEditorTemplate.IshField | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "EditorTemplate IshFoldersGroup Parameter IshFolder Multiple"
 			$ishFolderFavorites.IshField = $ishFolderFavorites.IshField | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "Favorites IshFoldersGroup Parameter IshFolder Multiple"
 			$ishFolders = Add-IshFolder -IshSession $ishSession -IshFolder @($ishFolderEditorTemplate,$ishFolderFavorites) -ParentFolderId $ishFolderCmdlet.IshFolderRef
-			$ishFolders.Count | Should Be 2
+			$ishFolders.Count | Should -Be 2
 		} #>
 		It "Pipeline IshLovValue Single" {
 			Remove-IshLovValue -IshSession $ishSession -LovId $ishLovId -LovValueId $lovValueId
 			$ishLovValues = $ishLovValue | Add-IshLovValue -IShSession $ishSession
-			$ishLovValues.Count | Should Be 1
+			$ishLovValues.Count | Should -Be 1
 		}
 		<# NotImplemented
 		It "Pipeline IshLovValue Multiple" {
 			$ishFolderData.IshField = $ishFolderData.IshField | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "EditorTemplate IshFoldersGroup Pipeline IshFolder Multiple"
 			$ishFolderSystem.IshField = $ishFolderSystem.IshField | Set-IshMetadataField -IshSession $ishSession -Name "FNAME" -Level None -Value "System IshFoldersGroup Pipeline IshFolder Multiple"
 			$ishFolders = @($ishFolderData,$ishFolderSystem) | Add-IshFolder -IshSession $ishSession -ParentFolderId $ishFolderCmdlet.IshFolderRef
-			$ishFolders.Count | Should Be 2
+			$ishFolders.Count | Should -Be 2
 		} #>
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$ishLovValues = Get-IshLovValue -IshSession $ishSession -LovId $ishLovId
 	foreach ($ishLovValue in $ishLovValues)
 	{
@@ -89,3 +91,4 @@ Describe “Add-IshLovValue" -Tags "Create" {
 		}
 	}
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/ListOfValues/GetIshLovValue.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/ListOfValues/GetIshLovValue.Tests.ps1
@@ -1,59 +1,59 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshLovValue"
-try {
-	
-Describe “Get-IshLovValue" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
+BeforeAll {
+	$cmdletName = "Get-IshLovValue"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-	Context “Get-IshLovValue ParameterGroup" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+	
+Describe "Get-IshLovValue" -Tags "Create" {
+	Context "Get-IshLovValue ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshLovValue -IShSession "INVALIDISHSESSION" -LovId $ishLovId -IshLovValue "ISHREMOTE$ishLovId" } | Should Throw
+			{ Get-IshLovValue -IShSession "INVALIDISHSESSION" -LovId $ishLovId -IshLovValue "ISHREMOTE$ishLovId" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshLovValue returns one IshLovValue object" {
-		$ishLovValueId = $ishLng
-		$ishLovValue = Get-IshLovValue -IShSession $ishSession -LovId $ishLovId -LovValueId $ishLovValueId
+		BeforeAll {
+			$ishLovValueId = $ishLng
+			$ishLovValue = Get-IshLovValue -IShSession $ishSession -LovId $ishLovId -LovValueId $ishLovValueId
+		}
 		It "GetType().Name" {
-			$ishLovValue.GetType().Name | Should BeExactly "IshLovValue"
+			$ishLovValue.GetType().Name | Should -BeExactly "IshLovValue"
 		}
 		It "ishLovValue.IshLovValueRef" {
-			$ishLovValue.IshLovValueRef -ge 0 | Should Be $true
+			$ishLovValue.IshLovValueRef -ge 0 | Should -Be $true
 		}
 		It "ishLovValue.LovId" {
-			$ishLovValue.LovId | Should Be "$ishLovId"
+			$ishLovValue.LovId | Should -Be "$ishLovId"
 		}
 		It "ishLovValue.IshRef" {
-			$ishLovValue.IshRef | Should be $ishLovValueId
+			$ishLovValue.IshRef | Should -Be $ishLovValueId
 		}
 		It "ishLovValue.Label" {
-			$ishLovValue.Label -ge 0 | Should Be $true
+			$ishLovValue.Label -ge 0 | Should -Be $true
 		}
 		It "ishLovValue.Description" {
-			$ishLovValue.Description -ge 0 | Should Be $true
+			$ishLovValue.Description -ge 0 | Should -Be $true
 		}
 		It "ishLovValue.Active" {
-			$ishLovValue.Active -ge 0 | Should Be $true
+			$ishLovValue.Active -ge 0 | Should -Be $true
 		}
 	}
-
 	Context "Get-IshLovValue returns two IshLovValue object" {
-		$ishLovValues = Get-IshLovValue -IShSession $ishSession -LovId ($ishLovId,$ishLovId2) -LovValueId ($ishLng,$ishResolution)
 		It "Count" {
-			$ishLovValues.Count | Should Be 2
+			$ishLovValues = Get-IshLovValue -IShSession $ishSession -LovId ($ishLovId,$ishLovId2) -LovValueId ($ishLng,$ishResolution)
+			$ishLovValues.Count | Should -Be 2
 		}
 	}
-
 	Context "Get-IshLovValue by LovId returns many IshLovValue objects" {
-		$ishLovValues = Get-IshLovValue -IShSession $ishSession -LovId $ishLovId 
 		It "Count" {
-			$ishLovValues.Count -ge 3 | Should Be $true
+			$ishLovValues = Get-IshLovValue -IShSession $ishSession -LovId $ishLovId 
+			$ishLovValues.Count -ge 3 | Should -Be $true
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/OutputFormat/AddIshOutputFormat.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/OutputFormat/AddIshOutputFormat.Tests.ps1
@@ -1,17 +1,17 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshOutputFormat"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshOutputFormat"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Add-IshOutputFormat" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
 	Context "Add-IshOutputFormat ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshOutputFormat -IShSession "INVALIDISHSESSION" -Name "INVALIDOUTPUTFORMATNAME" } | Should Throw
+			{ Add-IshOutputFormat -IShSession "INVALIDISHSESSION" -Name "INVALIDOUTPUTFORMATNAME" } | Should -Throw
 		}
 	}
-
 	Context "Add-IshOutputFormat ParameterGroup" {
 		It "GetType().Name" {
 			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
@@ -23,9 +23,9 @@ Describe "Add-IshOutputFormat" -Tags "Create" {
 			if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
 			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
 			$ishObject = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP"
-			$ishObject.GetType().Name | Should BeExactly "IshOutputFormat"
-			$ishObject.Count | Should Be 1
-			(ConvertTo-Json $ishObject).Length -gt 2 | Should Be $true
+			$ishObject.GetType().Name | Should -BeExactly "IshOutputFormat"
+			$ishObject.Count | Should -Be 1
+			(ConvertTo-Json $ishObject).Length -gt 2 | Should -Be $true
 		}
 		It "Parameter Metadata" {
 			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
@@ -37,8 +37,8 @@ Describe "Add-IshOutputFormat" -Tags "Create" {
 			if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
 			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
 			$ishObject = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP"
-			$ishObject.Count | Should Be 1
-			$ishObject.IshRef -Like "VOUTPUTFORMAT*" | Should Be $true
+			$ishObject.Count | Should -Be 1
+			$ishObject.IshRef -Like "VOUTPUTFORMAT*" | Should -Be $true
 		}
 		It "Parameter Metadata return descriptive metadata" {
 			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
@@ -51,10 +51,10 @@ Describe "Add-IshOutputFormat" -Tags "Create" {
 			if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
 			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
 			$ishObject = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP"
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name "FISHOUTPUTFORMATNAME" -Level None).Length -gt 1 | Should Be $true
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name "FISHOUTPUTFORMATNAME" -Level None).Length -gt 1 | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
 			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FISHCLEANUP" -Level None -Value "TRUE" |
 			            Set-IshMetadataField -IshSession $ishSession -Name "FISHKEEPDTDSYSTEMID" -Level None -Value "TRUE" |
@@ -65,9 +65,9 @@ Describe "Add-IshOutputFormat" -Tags "Create" {
 			if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
 			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
 			$ishObject = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP"
-			$ishObject.fishoutputformatname.Length -ge 1 | Should Be $true 
-			$ishObject.fishoutputedt.Length -ge 1 | Should Be $true 
-			$ishObject.fishoutputedt_none_element | Should Be "EDTZIP"
+			$ishObject.fishoutputformatname.Length -ge 1 | Should -Be $true 
+			$ishObject.fishoutputedt.Length -ge 1 | Should -Be $true 
+			$ishObject.fishoutputedt_none_element | Should -Be "EDTZIP"
 		}
 		It "Parameter Metadata StrictMetadataPreference=Off" {
 		    $strictMetadataPreference = $ishSession.StrictMetadataPreference
@@ -86,76 +86,77 @@ Describe "Add-IshOutputFormat" -Tags "Create" {
 						Set-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level None -Value "SomethingInvalidFieldName"
 			if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
 			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
-			{ Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" } | Should Throw
+			{ Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" } | Should -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 	}
-
 	Context "Add-IshOutputFormat IshObjectsGroup" {
-	    $metadata = Set-IshMetadataField -IshSession $ishSession -Name "FISHCLEANUP" -Level None -Value "TRUE" |
-			        Set-IshMetadataField -IshSession $ishSession -Name "FISHKEEPDTDSYSTEMID" -Level None -Value "TRUE" |
-					Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBRESOLVEVARIABLES" -Level None -Value "TRUE" |
-					Set-IshMetadataField -IshSession $ishSession -Name "FISHSINGLEFILE" -Level None -Value "TRUE" |
-					Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONS" -Level None -ValueType Element -Value $ishResolution
-		if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
-		if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
-		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHCLEANUP" -Level None |
-			                 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHKEEPDTDSYSTEMID" -Level None |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHPUBRESOLVEVARIABLES" -Level None |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHSINGLEFILE" -Level None |
-					         Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONS" -Level None -ValueType Element |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHOUTPUTEDT" -Level None -ValueType Element
-		if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $requestedMetadata = $requestedMetadata | Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None } # new mandatory field since 13SP2/13.0.2
-		$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
-		              Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
-		$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
-		              Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
-		$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
-		              Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
-		$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
-		              Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
-		$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
-		$ishObjectE = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
-		              Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
-		$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
-		$ishObjectF = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
-		              Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
-		Remove-IshOutputFormat -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
-		Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (VUSERROLEADD-IshOutputFormat20161012164716068A12/10/2016 16:47:16)."
+		BeforeAll {
+			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FISHCLEANUP" -Level None -Value "TRUE" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHKEEPDTDSYSTEMID" -Level None -Value "TRUE" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBRESOLVEVARIABLES" -Level None -Value "TRUE" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHSINGLEFILE" -Level None -Value "TRUE" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONS" -Level None -ValueType Element -Value $ishResolution
+			if (([Version]$ishSession.ServerVersion).Major -ge 13) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None -Value "TRUE" } # new mandatory field
+			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $metadata = $metadata | Set-IshMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None -ValueType Element -Value "VRESOLUTIONSTOEXPORTALLRESOLUTIONS" } # new mandatory field since 13SP2/13.0.2
+			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHCLEANUP" -Level None |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHKEEPDTDSYSTEMID" -Level None |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHPUBRESOLVEVARIABLES" -Level None |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHGUIDTOFILENAME" -Level None |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHSINGLEFILE" -Level None |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONS" -Level None -ValueType Element |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHOUTPUTEDT" -Level None -ValueType Element
+			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { $requestedMetadata = $requestedMetadata | Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHRESOLUTIONSTOEXPORT" -Level None } # new mandatory field since 13SP2/13.0.2
+			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
+						Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
+			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
+						Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
+			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
+						Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
+			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
+						Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
+			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
+						Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
+			$outputFormatName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshOutputFormat -IshSession $ishSession -Name $outputFormatName -Metadata $metadata -Edt "EDTZIP" | 
+						Get-IshOutputFormat -IshSession $ishSession -RequestedMetadata $requestedMetadata
+			Remove-IshOutputFormat -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
+			Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (VUSERROLEADD-IshOutputFormat20161012164716068A12/10/2016 16:47:16)."
+		}
 		It "Parameter IshObject invalid" {
-			{ Add-IshOutputFormat -IShSession $ishSession -IshObject "INVALIDOUTPUTFORMAT" } | Should Throw
+			{ Add-IshOutputFormat -IShSession $ishSession -IshObject "INVALIDOUTPUTFORMAT" } | Should -Throw
 		}
 		It "Parameter IshObject Single with optional IshSession" {
 			$ishObjects = Add-IshOutputFormat -IshObject $ishObjectA
 			$ishObjects | Remove-IshOutputFormat
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with optional IshSession" {
 			$ishObjects = Add-IshOutputFormat -IshObject @($ishObjectB,$ishObjectC)
 			$ishObjects | Remove-IshOutputFormat
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishObjects = $ishObjectD | Add-IshOutputFormat -IshSession $ishSession
 			$ishObjects | Remove-IshOutputFormat -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishObjects = @($ishObjectE,$ishObjectF) | Add-IshOutputFormat -IshSession $ishSession
 			$ishObjects | Remove-IshOutputFormat -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$userRoles = Find-IshOutputFormat -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "FISHOUTPUTFORMATNAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshOutputFormat -IshSession $ishSession -IshObject $userRoles } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/PublicationOutput/AddIshPublicationOutput.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/PublicationOutput/AddIshPublicationOutput.Tests.ps1
@@ -1,91 +1,93 @@
-﻿Write-Host("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path(Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshPublicationOutput"
-try {
-
-Describe “Add-IshPublicationOutput" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-
-    Write-Debug("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
-
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+BeforeAll {
+	$cmdletName = "Add-IshPublicationOutput"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 	
-    #$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    #$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	#$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	#$ishFolderOther = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "Other" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Map $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
-	                  Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
-	$ishObjectMap = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -LogicalId "MYOWNGENERATEDLOGICALIDMAP" -Version '3' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMapFileContent
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-    $ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-    $ishPubMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Pub $timestamp" |
-				      Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap.IshRef |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-                      Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPub = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -LogicalId "MYOWNGENERATEDLOGICALIDPUB" -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata
+Describe "Add-IshPublicationOutput" -Tags "Create" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
 
-	$tempFilePath = (New-TemporaryFile).FullName
+		Write-Debug("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-    Context "Add-IshPublicationOutput returns IshObject object" {
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 		
+		#$ishFolderTopic = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHModule -FolderName "Topic" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		#$ishFolderLib = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHLibrary -FolderName "Library" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		#$ishFolderImage = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHIllustration -FolderName "Image" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		#$ishFolderOther = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHTemplate -FolderName "Other" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderMap = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHMasterDoc -FolderName "Map" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishMapMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Map $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
+						Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
+		$ishObjectMap = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderMap -IshType ISHMasterDoc -LogicalId "MYOWNGENERATEDLOGICALIDMAP" -Version '3' -Lng $ishLng -Metadata $ishMapMetadata -Edt "EDTXML" -FileContent $ditaMapFileContent
+
+		$ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Pub" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishPubMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "All Parameters Pub $timestamp" |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHMASTERREF" -Level Version -ValueType Element -Value $ishObjectMap.IshRef |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+						Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+		$ishObjectPub = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -LogicalId "MYOWNGENERATEDLOGICALIDPUB" -Version '1' -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPubMetadata
+
+		$tempFilePath = (New-TemporaryFile).FullName
+	}
+    Context "Add-IshPublicationOutput returns IshObject object" {
         It "GetType().Name" {
-			$ishObjectPub.GetType().Name | Should BeExactly "IshPublicationOutput"
+			$ishObjectPub.GetType().Name | Should -BeExactly "IshPublicationOutput"
 		}
 		It "ishObjectPub.IshField" {
-			$ishObjectPub.IshField | Should Not BeNullOrEmpty
+			$ishObjectPub.IshField | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjectPub.IshRef" {
-			$ishObjectPub.IshRef | Should Not BeNullOrEmpty
+			$ishObjectPub.IshRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjectPub.IshType" {
-			$ishObjectPub.IshType | Should Not BeNullOrEmpty
+			$ishObjectPub.IshType | Should -Not -BeNullOrEmpty
 		}
 		# Double check following 3 ReferenceType enum usage 
 		It "ishObjectPub.ObjectRef" {
-			$ishObjectPub.ObjectRef | Should Not BeNullOrEmpty
+			$ishObjectPub.ObjectRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjectPub.VersionRef" {
-			$ishObjectPub.VersionRef | Should Not BeNullOrEmpty
+			$ishObjectPub.VersionRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjectPub.LngRef" {
-			$ishObjectPub.LngRef | Should Not BeNullOrEmpty
+			$ishObjectPub.LngRef | Should -Not -BeNullOrEmpty
 		}
 		It "ishObjectPub ConvertTo-Json" {
-			(ConvertTo-Json $ishObjectPub).Length -gt 2 | Should Be $true
+			(ConvertTo-Json $ishObjectPub).Length -gt 2 | Should -Be $true
 		}
 		It "Option IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 			#logical
-			$ishObjectPub.ftitle_logical_value.Length -ge 1 | Should Be $true 
+			$ishObjectPub.ftitle_logical_value.Length -ge 1 | Should -Be $true 
 			#version
-			$ishObjectPub.version_version_value.Length -ge 1 | Should Be $true 
+			$ishObjectPub.version_version_value.Length -ge 1 | Should -Be $true 
 			#language
-			$ishObjectPub.fishpubstatus.Length -ge 1 | Should Be $true 
-			$ishObjectPub.fishpubstatus_lng_element.StartsWith('VPUBSTATUS') | Should Be $true 
-			$ishObjectPub.fishpublngcombination.Length -ge 1 | Should Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
-			#$ishObjectPub.fishpublngcombination_lng_element.StartsWith('VLANGUAGE') | Should Be $true # Note that fishpublngcombination is a string like 'en+fr+nl' so doesn't have element name
+			$ishObjectPub.fishpubstatus.Length -ge 1 | Should -Be $true 
+			$ishObjectPub.fishpubstatus_lng_element.StartsWith('VPUBSTATUS') | Should -Be $true 
+			$ishObjectPub.fishpublngcombination.Length -ge 1 | Should -Be $true  # Field names like DOC-LANGUAGE get stripped of the hyphen, otherwise you get $ishObject.'doc-language' and now you get the more readable $ishObject.doclanguage
+			#$ishObjectPub.fishpublngcombination_lng_element.StartsWith('VLANGUAGE') | Should -Be $true # Note that fishpublngcombination is a string like 'en+fr+nl' so doesn't have element name
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
     try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Where-Object -Property IshFolderType -EQ -Value "ISHPublication" | Get-IshFolderContent -IshSession $ishSession | Remove-IshPublicationOutput -IshSession $ishSession -Force } catch { }
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshDocumentObj -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 	try { Remove-Item $tempFilePath -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/PublicationOutput/GetPublicationOutputFolderLocation.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/PublicationOutput/GetPublicationOutputFolderLocation.Tests.ps1
@@ -1,74 +1,78 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshPublicationOutputFolderLocation"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshPublicationOutputFolderLocation"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshPublicationOutputFolderLocation" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
-	                     Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
-	$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
-	$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
-	$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
-	Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
-	$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
-	$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
-	$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
-	$ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Publication" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+Describe "Get-IshPublicationOutputFolderLocation" -Tags "Read" {
+	BeforeAll {
+		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FNAME" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FDOCUMENTTYPE" |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element |
+							Set-IshRequestedMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element 
+		$ishFolderTestRootOriginal = Get-IshFolder -IShSession $ishSession -FolderPath $folderTestRootPath -RequestedMetadata $requestedMetadata
+		$folderIdTestRootOriginal = $ishFolderTestRootOriginal.IshFolderRef
+		$folderTypeTestRootOriginal = $ishFolderTestRootOriginal.IshFolderType
+		Write-Debug ("folderIdTestRootOriginal[" + $folderIdTestRootOriginal + "] folderTypeTestRootOriginal[" + $folderTypeTestRootOriginal + "]")
+		$ownedByTestRootOriginal = Get-IshMetadataField -IshSession $ishSession -Name "FUSERGROUP" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField
+		$readAccessTestRootOriginal = (Get-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -ValueType Element -IshField $ishFolderTestRootOriginal.IshField).Split($ishSession.Separator)
 
-	$ishPublicationOutputMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
-	                    Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
-	                    Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
-	$ishObjectPubA = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPublicationOutputMetadata
-	$ishObjectPubB = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPublicationOutputMetadata
+		$global:ishFolderCmdlet = Add-IshFolder -IShSession $ishSession -ParentFolderId $folderIdTestRootOriginal -FolderType $folderTypeTestRootOriginal -FolderName $cmdletName -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
+		$ishFolderPub = Add-IshFolder -IshSession $ishSession -ParentFolderId ($global:ishFolderCmdlet.IshFolderRef) -FolderType ISHPublication -FolderName "Publication" -OwnedBy $ownedByTestRootOriginal -ReadAccess $readAccessTestRootOriginal
 
+		$ishPublicationOutputMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Pub $timestamp" |
+							Set-IshMetadataField -IshSession $ishSession -Name "FISHPUBSOURCELANGUAGES" -Level Version -ValueType Element -Value $ishLng |
+							Set-IshMetadataField -IshSession $ishSession -Name "FISHREQUIREDRESOLUTIONS" -Level Version -ValueType Element -Value $ishResolution
+		$ishObjectPubA = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPublicationOutputMetadata
+		$ishObjectPubB = Add-IshPublicationOutput -IshSession $ishSession -IshFolder $ishFolderPub -LanguageCombination $ishLngCombination -OutputFormat $ishOutputFormatDitaXml -Metadata $ishPublicationOutputMetadata
+	}
 	Context "Get-IshPublicationOutputFolderLocation ParameterGroup" {
-		It "Parameter IshSession/LogicalId invalid" {
-			{ Get-IshPublicationOutputFolderLocation -IShSession "INVALIDISHSESSION" -LogicalId "INVALIDLOGICALID" } | Should Throw
+		BeforeAll {
+			$folderPath = Get-IshPublicationOutputFolderLocation -IshSession $ishSession -LogicalId $ishObjectPubA.IshRef
 		}
-		$folderPath = Get-IshPublicationOutputFolderLocation -IshSession $ishSession -LogicalId $ishObjectPubA.IshRef
+		It "Parameter IshSession/LogicalId invalid" {
+			{ Get-IshPublicationOutputFolderLocation -IShSession "INVALIDISHSESSION" -LogicalId "INVALIDLOGICALID" } | Should -Throw
+		}
 		It "GetType().Name" {
-			$folderPath.GetType().Name | Should BeExactly "String"
+			$folderPath.GetType().Name | Should -BeExactly "String"
 		}
 		It "Parameter LogicalId Single" {
-			$folderPath | Should BeExactly (Join-Path (Join-Path $folderTestRootPath $cmdletName) "Publication")
+			$folderPath | Should -BeExactly (Join-Path (Join-Path $folderTestRootPath $cmdletName) "Publication")
 		}
 		It "Leading IshSession.FolderPathSeparator" {
-			$folderPath[0] | Should Be $ishSession.FolderPathSeparator
+			$folderPath[0] | Should -Be $ishSession.FolderPathSeparator
 		}
 	}
-
 	Context "Get-IshPublicationOutputFolderLocation IshObjectGroup" {
 		It "GetType().Name" {
 			$folderPathArray = Get-IshPublicationOutputFolderLocation -IshSession $ishSession -IshObject @($ishObjectPubA,$ishObjectPubB)
-			$folderPathArray.GetType().Name | Should BeExactly "Object[]"
+			$folderPathArray.GetType().Name | Should -BeExactly "Object[]"
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			$folderPathArray = Get-IshPublicationOutputFolderLocation -IshObject $ishObjectPubA
-			$folderPathArray.Count | Should Be 1
+			$folderPathArray.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 			$folderPathArray = Get-IshPublicationOutputFolderLocation -IshObject @($ishObjectPubA,$ishObjectPubB)
-			$folderPathArray.Count | Should Be 2
+			$folderPathArray.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$folderPathArray = $ishObjectPubA | Get-IshPublicationOutputFolderLocation -IshSession $ishSession
-			$folderPathArray.Count | Should Be 1
+			$folderPathArray.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$folderPathArray = @($ishObjectPubA,$ishObjectPubB) | Get-IshPublicationOutputFolderLocation -IshSession $ishSession
-			$folderPathArray.Count | Should Be 2
+			$folderPathArray.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$folderCmdletRootPath = (Join-Path $folderTestRootPath $cmdletName)
 	try { Get-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse | Get-IshFolderContent -IshSession $ishSession | Remove-IshPublicationOutput -IshSession $ishSession -Force } catch { }
 	try { Remove-IshFolder -IshSession $ishSession -FolderPath $folderCmdletRootPath -Recurse } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Session/NewIshSession.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Session/NewIshSession.Tests.ps1
@@ -1,41 +1,42 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "New-IshSession"
-try {
+﻿BeforeAll {
+	$cmdletName = "New-IshSession"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+	
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+	$ishSession = $null  # Resetting generic $ishSession
+}
 
 Describe "New-IshSession" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-	$ishSession = $null  # Resetting generic $ishSession
-
 	Context "New-IshSession ISHDeploy::Enable-ISHIntegrationSTSInternalAuthentication/Prepare-SupportAccess.ps1" {
 		It "Parameter WsBaseUrl contains 'SDL' (legacy script)" -skip {
 			$ishSession = New-IshSession -WsBaseUrl https://example.com/ISHWS/SDL/ -IshUserName x -IshPassword y
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
 		}
 		It "Parameter WsBaseUrl contains 'Internal' (ISHDeploy)" -skip {
 			$ishSession = New-IshSession -WsBaseUrl https://example.com/ISHWS/Internal/ -IshUserName x -IshPassword y
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
 		}
 	}
 
 	Context “New-IshSession UserNamePassword" {
 		It "Parameter WsBaseUrl invalid" {
-			{ New-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" } | Should Throw "Invalid URI"
+			{ New-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" } | Should -Throw "Invalid URI: The hostname could not be parsed."
 		}
 		It "Parameter IshUserName invalid" {
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" } | Should Throw
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" } | Should -Throw
 		}
 		It "Parameter IshPassword specified" {
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName $ishUserName -IshPassword "INVALIDISHPASSWORD" } | Should Throw
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName $ishUserName -IshPassword "INVALIDISHPASSWORD" } | Should -Throw
 		}
 		It "Parameter IshUserName empty falls back to NetworkCredential/ActiveDirectory" {
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName "" -IshPassword "IGNOREISHPASSWORD" } | Should Not Throw "Cannot validate argument on parameter 'IshUserName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName "" -IshPassword "IGNOREISHPASSWORD" } | Should -Not Throw "Cannot validate argument on parameter 'IshUserName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
 		}
 	}
 
 	Context “New-IshSession ActiveDirectory" {
 		It "Parameter WsBaseUrl invalid" {
-			{ New-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" } | Should Throw "Invalid URI"
+			{ New-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" } | Should -Throw "Invalid URI: The hostname could not be parsed."
 		}
 	}
 
@@ -45,146 +46,148 @@ Describe "New-IshSession" -Tags "Read" {
 				$securePassword = ConvertTo-SecureString $ishPassword -AsPlainText -Force
 				$mycredentials = New-Object System.Management.Automation.PSCredential ($ishUserName, $securePassword)
 				New-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -PSCredential $mycredentials
-			} | Should Throw "Invalid URI"
+			} | Should -Throw "Invalid URI"
 		}
 		It "Parameter PSCredential invalid" {
 			$securePassword = ConvertTo-SecureString "INVALIDPASSWORD" -AsPlainText -Force
 			$mycredentials = New-Object System.Management.Automation.PSCredential ("INVALIDISHUSERNAME", $securePassword)
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials } | Should Throw
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials } | Should -Throw
 		}
 		It "Parameter PSCredential" {
 			$securePassword = ConvertTo-SecureString $ishPassword -AsPlainText -Force
 			$mycredentials = New-Object System.Management.Automation.PSCredential ($ishUserName, $securePassword)
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials } | Should Not Throw
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials } | Should -Not Throw
 		}
 	}
 
 	Context "New-IshSession returns IshSession object" {
-		$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword
+		BeforeAll {
+			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword
+		}
 		It "GetType()" {
-			$ishSession.GetType().Name | Should BeExactly "IshSession"
+			$ishSession.GetType().Name | Should -BeExactly "IshSession"
 		}
 		It "IshSession.AuthenticationContext" {
-			$ishSession.AuthenticationContext | Should Not BeNullOrEmpty
+			$ishSession.AuthenticationContext | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.BlobBatchSize" {
-			$ishSession.BlobBatchSize -gt 0 | Should Be $true
+			$ishSession.BlobBatchSize -gt 0 | Should -Be $true
 		}
 		It "IshSession.ChunkSize" {
-			$ishSession.ChunkSize -gt 0 | Should Be $true
+			$ishSession.ChunkSize -gt 0 | Should -Be $true
 		}
 		It "IshSession.ClientVersion" {
-			$ishSession.ClientVersion | Should Not BeNullOrEmpty
+			$ishSession.ClientVersion | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.ClientVersion not 0.0.0.0" {
-			$ishSession.ClientVersion | Should Not Be "0.0.0.0"
+			$ishSession.ClientVersion | Should -Not -Be "0.0.0.0"
 		}
 		It "IshSession.FolderPathSeparator" {
-			$ishSession.FolderPathSeparator | Should Be "\"
+			$ishSession.FolderPathSeparator | Should -Be "\"
 		}
 		It "IshSession.IshUserName" {
-			$ishSession.IshUserName | Should Not BeNullOrEmpty
+			$ishSession.IshUserName | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.UserName" {
-			$ishSession.UserName | Should Not BeNullOrEmpty
+			$ishSession.UserName | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.IshTypeFieldDefinition" {
-			$ishSession.IshTypeFieldDefinition | Should Not BeNullOrEmpty
+			$ishSession.IshTypeFieldDefinition | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.IshTypeFieldDefinition.Count" {
-			$ishSession.IshTypeFieldDefinition.Count -gt 460 | Should Be $true
+			$ishSession.IshTypeFieldDefinition.Count -gt 460 | Should -Be $true
 		}
 		It "IshSession.IshTypeFieldDefinition.GetType().Name" {
-			$ishSession.IshTypeFieldDefinition[0].GetType().Name | Should BeExactly "IshTypeFieldDefinition"
-			$ishSession.IshTypeFieldDefinition[0].ISHType | Should Not BeNullOrEmpty
-			$ishSession.IshTypeFieldDefinition[0].Level | Should Not BeNullOrEmpty
-			$ishSession.IshTypeFieldDefinition[0].Name | Should Not BeNullOrEmpty
-			$ishSession.IshTypeFieldDefinition[0].DataType | Should Not BeNullOrEmpty
+			$ishSession.IshTypeFieldDefinition[0].GetType().Name | Should -BeExactly "IshTypeFieldDefinition"
+			$ishSession.IshTypeFieldDefinition[0].ISHType | Should -Not -BeNullOrEmpty
+			$ishSession.IshTypeFieldDefinition[0].Level | Should -Not -BeNullOrEmpty
+			$ishSession.IshTypeFieldDefinition[0].Name | Should -Not -BeNullOrEmpty
+			$ishSession.IshTypeFieldDefinition[0].DataType | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.MetadataBatchSize" {
-			$ishSession.MetadataBatchSize -gt 0 | Should Be $true
+			$ishSession.MetadataBatchSize -gt 0 | Should -Be $true
 		}
 		It "IshSession.Separator" {
-			$ishSession.Separator | Should Be ", "
+			$ishSession.Separator | Should -Be ", "
 		}
 		It "IshSession.ServerVersion empty (ISHWS down?)" {
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.ServerVersion not 0.0.0.0" {
-			$ishSession.ServerVersion | Should Not Be "0.0.0.0"
+			$ishSession.ServerVersion | Should -Not -Be "0.0.0.0"
 		}
 		It "IshSession.ServerVersion contains 4 dot-seperated parts" {
-			$ishSession.ServerVersion.Split(".").Length | Should Be 4
+			$ishSession.ServerVersion.Split(".").Length | Should -Be 4
 		}
 		It "IshSession.Timeout defaults to 20s" {
-			$ishSession.Timeout.TotalMilliseconds -eq 20000 | Should Be $true
+			$ishSession.Timeout.TotalMilliseconds -eq 20000 | Should -Be $true
 		}
 		It "IshSession.TimeoutIssue defaults to 30m" {
-			$ishSession.TimeoutIssue.TotalMilliseconds -eq 1800000 | Should Be $true
+			$ishSession.TimeoutIssue.TotalMilliseconds -eq 1800000 | Should -Be $true
 		}
 		It "IshSession.TimeoutService defaults to 30m" {
-			$ishSession.TimeoutService.TotalMilliseconds -eq 1800000 | Should Be $true
+			$ishSession.TimeoutService.TotalMilliseconds -eq 1800000 | Should -Be $true
 		}
 		It "IshSession.StrictMetadataPreference" {
-			$ishSession.StrictMetadataPreference | Should Be "Continue"
+			$ishSession.StrictMetadataPreference | Should -Be "Continue"
 		}
 		It "IshSession.PipelineObjectPreference" {
-			$ishSession.PipelineObjectPreference | Should Be "PSObjectNoteProperty"
+			$ishSession.PipelineObjectPreference | Should -Be "PSObjectNoteProperty"
 		}
 		It "IshSession.DefaultRequestedMetadata" {
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
 		}
 		It "IshSession.WebServicesBaseUrl" {
-			$ishSession.WebServicesBaseUrl | Should Not BeNullOrEmpty
+			$ishSession.WebServicesBaseUrl | Should -Not -BeNullOrEmpty
 		}
 	}
 
 	Context "New-IshSession WsBaseUrl without ending slash" {
-		# .NET throws unhandy "Reference to undeclared entity 'raquo'." error
-		$webServicesBaseUrlWithoutEndingSlash = $webServicesBaseUrl.Substring(0,$webServicesBaseUrl.Length-1)
 		It "WsBaseUrl without ending slash" {
-			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrlWithoutEndingSlash -IshUserName $ishUserName -IshPassword $ishPassword } | Should Not Throw
+			# .NET throws unhandy "Reference to undeclared entity 'raquo'." error
+			$webServicesBaseUrlWithoutEndingSlash = $webServicesBaseUrl.Substring(0,$webServicesBaseUrl.Length-1)
+			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrlWithoutEndingSlash -IshUserName $ishUserName -IshPassword $ishPassword } | Should -Not Throw
 		}
 	}
 
 	Context "New-IshSession Timeout" {
 		It "Parameter Timeout Invalid" {
-			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout "INVALIDTIMEOUT" } | Should Throw
+			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout "INVALIDTIMEOUT" } | Should -Throw
 		}
 		It "IshSession.Timeout set to 30s" {
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout (New-TimeSpan -Seconds 60)
-			$ishSession.Timeout.TotalMilliseconds  | Should Be "60000"
+			$ishSession.Timeout.TotalMilliseconds  | Should -Be "60000"
 		}
 		It "IshSession.Timeout on INVALID url set to 1ms execution" {
 			# TaskCanceledException: A task was canceled.
 			{
 				$invalidWebServicesBaseUrl = $webServicesBaseUrl -replace "://", "://INVALID"
 				$ishSession = New-IshSession -WsBaseUrl $invalidWebServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout (New-Object TimeSpan(0,0,0,0,1))
-			} | Should Throw
+			} | Should -Throw
 		}
 	}
 
 	Context "New-IshSession TimeoutIssue" {
 		It "Parameter TimeoutIssue Invalid" {
-			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue "INVALIDTimeoutIssue" } | Should Throw
+			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue "INVALIDTimeoutIssue" } | Should -Throw
 		}
 		It "IshSession.TimeoutIssue set to 30s" {
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue (New-TimeSpan -Seconds 30)
-			$ishSession.TimeoutIssue.TotalMilliseconds  | Should Be "30000"
+			$ishSession.TimeoutIssue.TotalMilliseconds  | Should -Be "30000"
 		}
 		It "IshSession.TimeoutIssue set to 1ms execution" {
 			# The request channel timed out while waiting for a reply after 00:00:00.0000017. Increase the timeout value passed to the call to Request or increase the SendTimeout value on the Binding. The time allotted to this operation may have been a portion of a longer timeout.
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue (New-Object TimeSpan(0,0,0,0,1)) } | Should Throw
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue (New-Object TimeSpan(0,0,0,0,1)) } | Should -Throw
 		}
 	}
 	
 	Context "New-IshSession TimeoutService" {
 		It "Parameter TimeoutService Invalid" {
-			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutService "INVALIDTIMEOUTSERVICE" } | Should Throw
+			{ $ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutService "INVALIDTIMEOUTSERVICE" } | Should -Throw
 		}
 		It "IshSession.TimeoutService set to 40s" {
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutService (New-TimeSpan -Seconds 40)
-			$ishSession.TimeoutService.TotalMilliseconds  | Should Be "40000"
+			$ishSession.TimeoutService.TotalMilliseconds  | Should -Be "40000"
 		}
 		It "IshSession.TimeoutService set to 1 tickout execution" {
 			# The request channel timed out attempting to send after 00:00:00.0010000. Increase the timeout value passed to the call to Request or increase the SendTimeout value on the Binding. The time allotted to this operation may have been a portion of a longer timeout.
@@ -192,15 +195,15 @@ Describe "New-IshSession" -Tags "Read" {
 				$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutService (New-Object TimeSpan(1)) 
 				# Forcing a GetVersion web service call, probably needs a better call because GetVersion can be too fast, so nothing is thrown, perhaps IshTypeFieldDefinition
 				$ishTypeFieldDefinition = $ishSession.IshTypeFieldDefinition
-			} | Should Throw
+			} | Should -Throw
 		}
 	}
 
 	Context "New-IshSession IgnoreSslPolicyErrors" {
 		It "Parameter IgnoreSslPolicyErrors specified positive flow" {
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
-			$ishSession.ServerVersion.Split(".").Length | Should Be 4
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
+			$ishSession.ServerVersion.Split(".").Length | Should -Be 4
 		}
 		It "Parameter IgnoreSslPolicyErrors specified negative flow (segment-one-url)" -skip {
 			# replace hostname like machinename.somedomain.com to machinename only, marked as skipped for non-development machines
@@ -211,8 +214,8 @@ Describe "New-IshSession" -Tags "Read" {
 			$computername = $hostname.Substring(0,$hostname.IndexOf("."))
 			$webServicesBaseUrlToComputerName = $webServicesBaseUrl.Replace($hostname,$computername)
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrlToComputerName -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
-			$ishSession.ServerVersion.Split(".").Length | Should Be 4
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
+			$ishSession.ServerVersion.Split(".").Length | Should -Be 4
 			$ishSession.Dispose()
 		}
 		<# It "Parameter IgnoreSslPolicyErrors specified negative flow (Resolve-DnsName)" -skip {
@@ -224,91 +227,92 @@ Describe "New-IshSession" -Tags "Read" {
 			$ipAddress = Resolve-DnsName –Name $hostname  # only available on Windows Server 2012 R2 and Windows 8.1
 			$webServicesBaseUrlToIpAddress = $webServicesBaseUrl.Replace($hostname,$ipAddress)
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrlToIpAddress -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
-			$ishSession.ServerVersion.Split(".").Length | Should Be 4
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
+			$ishSession.ServerVersion.Split(".").Length | Should -Be 4
 			$ishSession.Dispose()
 		} #>
 	}
 	Context "New-IshSession ExplicitIssuer" {
 		It "Parameter WsTrustIssuerUrl and WsTrustIssuerMexUrl are using full hostname" {
 			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -WsTrustIssuerUrl $wsTrustIssuerUrl -WsTrustIssuerMexUrl $wsTrustIssuerMexUrl -IshUserName $ishUserName -IshPassword $ishPassword
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
-			$ishSession.ServerVersion.Split(".").Length | Should Be 4
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
+			$ishSession.ServerVersion.Split(".").Length | Should -Be 4
 		}
 		It "Parameter WsTrustIssuerUrl and WsTrustIssuerMexUrl are using localhost" -skip {
 			$ishSession = New-IshSession -WsBaseUrl $localWebServicesBaseUrl -WsTrustIssuerUrl $localWsTrustIssuerUrl -WsTrustIssuerMexUrl $localWsTrustIssuerMexUrl -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors
-			$ishSession.ServerVersion | Should Not BeNullOrEmpty
-			$ishSession.ServerVersion.Split(".").Length | Should Be 4
+			$ishSession.ServerVersion | Should -Not -BeNullOrEmpty
+			$ishSession.ServerVersion.Split(".").Length | Should -Be 4
 		}
 	}
 
 	Context "New-IshSession returns IshSession ServiceReferences" {
-		$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword
+		BeforeAll {
+			$ishSession = New-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword
+		}
 		It "IshSession.Annotation25" {
 			if (([Version]$ishSession.ServerVersion).Major -ge 14) { # new service since 14/14.0.0
-				 $ishSession.Annotation25 -ne $null | Should Not BeNullOrEmpty
+				 $ishSession.Annotation25 -ne $null | Should -Not -BeNullOrEmpty
 			}
 		}
 		It "IshSession.Application25" {
-			$ishSession.Application25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.Application25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.BackgroundTask25" { # new service since 13SP2/13.0.2
 			if (([Version]$ishSession.ServerVersion).Major -ge 14 -or (([Version]$ishSession.ServerVersion).Major -ge 13 -and ([Version]$ishSession.ServerVersion).Revision -ge 2)) { 
-				$ishSession.BackgroundTask25 -ne $null | Should Not BeNullOrEmpty
+				$ishSession.BackgroundTask25 -ne $null | Should -Not -BeNullOrEmpty
 			}
 		}
 		It "IshSession.Baseline25" {
-			$ishSession.Baseline25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.Baseline25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.DocumentObj25" {
-			$ishSession.DocumentObj25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.DocumentObj25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.EDT25" {
-			$ishSession.EDT25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.EDT25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.EventMonitor25" {
-			$ishSession.EventMonitor25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.EventMonitor25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.Folder25" {
-			$ishSession.Folder25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.Folder25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.ListOfValues25" {
-			$ishSession.ListOfValues25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.ListOfValues25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.MetadataBinding25" {
-			$ishSession.MetadataBinding25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.MetadataBinding25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.OutputFormat25" {
-			$ishSession.OutputFormat25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.OutputFormat25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.PublicationOutput25" {
-			$ishSession.PublicationOutput25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.PublicationOutput25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.Search25" {
-			$ishSession.Search25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.Search25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.Settings25" {
-			$ishSession.Settings25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.Settings25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.TranslationJob25" {
-			$ishSession.TranslationJob25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.TranslationJob25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.TranslationTemplate25" {
-			$ishSession.TranslationTemplate25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.TranslationTemplate25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.User25" {
-			$ishSession.User25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.User25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.UserGroup25" {
-			$ishSession.UserGroup25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.UserGroup25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 		It "IshSession.UserRole25" {
-			$ishSession.UserRole25 -ne $null | Should Not BeNullOrEmpty
+			$ishSession.UserRole25 -ne $null | Should -Not -BeNullOrEmpty
 		}
 	}
 }
 
-	
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Session/TestIshSession.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Session/TestIshSession.Tests.ps1
@@ -1,38 +1,39 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Test-IshSession"
-try {
+﻿BeforeAll {
+	$cmdletName = "Test-IshSession"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+	
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Test-IshSession" -Tags "Read" {
-	Write-Host "Initializing Test Data and Variables"
-
 	Context "Test-IshSession ISHDeploy::Enable-ISHIntegrationSTSInternalAuthentication/Prepare-SupportAccess.ps1" {
-		It "Parameter WsBaseUrl contains 'SDL' (legacy script)" -skip {
-			Test-IshSession -WsBaseUrl https://example.com/ISHWS/SDL/ -IshUserName x -IshPassword y | Should Be $true
+		It "Parameter WsBaseUrl contains 'SDL' (legacy script)" -Skip {
+			Test-IshSession -WsBaseUrl https://example.com/ISHWS/SDL/ -IshUserName x -IshPassword y | Should -Be $true
 		}
-		It "Parameter WsBaseUrl contains 'Internal' (ISHDeploy)" -skip {
-			Test-IshSession -WsBaseUrl https://example.com/ISHWS/Internal/ -IshUserName x -IshPassword y | Should Be $true
+		It "Parameter WsBaseUrl contains 'Internal' (ISHDeploy)" -Skip {
+			Test-IshSession -WsBaseUrl https://example.com/ISHWS/Internal/ -IshUserName x -IshPassword y | Should -Be $true
 		}
 	}
 
 	Context “Test-IshSession UserNamePassword" {
 		It "Parameter WsBaseUrl invalid" {
-			Test-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" | Should Be $false
+			Test-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" | Should -Be $false
 		}
 		It "Parameter IshUserName invalid" {
-			Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" | Should Be $false
+			Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName "INVALIDISHUSERNAME" -IshPassword "INVALIDISHPASSWORD" | Should -Be $false
 		}
 		It "Parameter IshPassword specified" {
-			Test-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName $ishUserName -IshPassword "INVALIDISHPASSWORD" | Should Be $false
+			Test-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName $ishUserName -IshPassword "INVALIDISHPASSWORD" | Should -Be $false
 		}
-		It "Parameter IshUserName empty falls back to NetworkCredential/ActiveDirectory" {
-			{ New-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName "" -IshPassword "IGNOREISHPASSWORD" } | Should Not Throw "Cannot validate argument on parameter 'IshUserName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+		It "Parameter IshUserName empty falls back to NetworkCredential/ActiveDirectory" -Skip:(-Not $isISHRemoteWindowsAuthentication) {
+			{ New-IshSession -WsBaseUrl $webServicesBaseUrl  -IshUserName "" -IshPassword "IGNOREISHPASSWORD" } | Should -Not -Throw "Cannot validate argument on parameter 'IshUserName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
 		}
 	}
 
 	Context “Test-IshSession ActiveDirectory" {
 		It "Parameter WsBaseUrl invalid" {
-			Test-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" | Should Be $false
+			Test-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" | Should -Be $false
 		}
 	}
 
@@ -40,64 +41,66 @@ Describe "Test-IshSession" -Tags "Read" {
 		It "Parameter WsBaseUrl invalid" {
 			$securePassword = ConvertTo-SecureString $ishPassword -AsPlainText -Force
 			$mycredentials = New-Object System.Management.Automation.PSCredential ($ishUserName, $securePassword)
-			Test-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -PSCredential $mycredentials | Should Be $false
+			Test-IshSession -WsBaseUrl "http:///INVALIDWSBASEURL" -PSCredential $mycredentials | Should -Be $false
 		}
 		It "Parameter PSCredential invalid" {
 			$securePassword = ConvertTo-SecureString "INVALIDPASSWORD" -AsPlainText -Force
 			$mycredentials = New-Object System.Management.Automation.PSCredential ("INVALIDISHUSERNAME", $securePassword)
-			Test-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials | Should Be $false
+			Test-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials | Should -Be $false
 		}
 		It "Parameter PSCredential" {
 			$securePassword = ConvertTo-SecureString $ishPassword -AsPlainText -Force
 			$mycredentials = New-Object System.Management.Automation.PSCredential ($ishUserName, $securePassword)
-			Test-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials | Should Be $true
+			Test-IshSession -WsBaseUrl $webServicesBaseUrl -PSCredential $mycredentials | Should -Be $true
 		}
 	}
 
 	Context "Test-IshSession returns bool" {
-		$ishSessionResult = Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword
+		BeforeAll {
+			$ishSessionResult = Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword
+		}
 		It "GetType()" {
-			$ishSessionResult.GetType().Name | Should BeExactly "Boolean"
+			$ishSessionResult.GetType().Name | Should -BeExactly "Boolean"
 		}
 	}
 
 	Context "Test-IshSession WsBaseUrl without ending slash" {
-		# .NET throws unhandy "Reference to undeclared entity 'raquo'." error
-		$webServicesBaseUrlWithoutEndingSlash = $webServicesBaseUrl.Substring(0,$webServicesBaseUrl.Length-1)
 		It "WsBaseUrl without ending slash" {
-			Test-IshSession -WsBaseUrl $webServicesBaseUrlWithoutEndingSlash -IshUserName $ishUserName -IshPassword $ishPassword | Should Be $true
+			# .NET throws unhandy "Reference to undeclared entity 'raquo'." error
+			$webServicesBaseUrlWithoutEndingSlash = $webServicesBaseUrl.Substring(0,$webServicesBaseUrl.Length-1)
+			Test-IshSession -WsBaseUrl $webServicesBaseUrlWithoutEndingSlash -IshUserName $ishUserName -IshPassword $ishPassword | Should -Be $true
 		}
 	}
 
 	Context "Test-IshSession Timeout" {
 		It "Parameter Timeout Invalid" {
-			{ Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout "INVALIDTIMEOUT" } | Should Throw
+			{ Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout "INVALIDTIMEOUT" } | Should -Throw
 		}
 		It "IshSession.Timeout on INVALID url set to 1ms execution" {
 			# TaskCanceledException: A task was canceled.
 			$invalidWebServicesBaseUrl = $webServicesBaseUrl -replace "://", "://INVALID"
-			Test-IshSession -WsBaseUrl $invalidWebServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout (New-Object TimeSpan(0,0,0,0,1)) | Should Be $false
+			Test-IshSession -WsBaseUrl $invalidWebServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -Timeout (New-Object TimeSpan(0,0,0,0,1)) | Should -Be $false
 		}
 	}
 
 	Context "Test-IshSession TimeoutIssue" {
 		It "Parameter TimeoutIssue Invalid" {
-			{ Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue "INVALIDTimeoutIssue" } | Should Throw
+			{ Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue "INVALIDTimeoutIssue" } | Should -Throw
 		}
 		It "IshSession.TimeoutIssue set to 1ms execution" {
 			# The request channel timed out while waiting for a reply after 00:00:00.0000017. Increase the timeout value passed to the call to Request or increase the SendTimeout value on the Binding. The time allotted to this operation may have been a portion of a longer timeout.
-			Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue (New-Object TimeSpan(0,0,0,0,1)) | Should Be $false
+			Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutIssue (New-Object TimeSpan(0,0,0,0,1)) | Should -Be $false
 		}
 	}
 	
 	Context "Test-IshSession TimeoutService" {
 		It "Parameter TimeoutService Invalid" {
-			{ Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutService "INVALIDTIMEOUTSERVICE" } | Should Throw
+			{ Test-IshSession -WsBaseUrl $webServicesBaseUrl -IshUserName $ishUserName -IshPassword $ishPassword -TimeoutService "INVALIDTIMEOUTSERVICE" } | Should -Throw
 		}
 	}
 
 	Context "Test-IshSession IgnoreSslPolicyErrors" {
-		It "Parameter IgnoreSslPolicyErrors specified negative flow (segment-one-url)" -skip {
+		It "Parameter IgnoreSslPolicyErrors specified negative flow (segment-one-url)" -Skip {
 			# replace hostname like machinename.somedomain.com to machinename only, marked as skipped for non-development machines
 			$slash1Position = $webServicesBaseUrl.IndexOf("/")
 			$slash2Position = $webServicesBaseUrl.IndexOf("/",$slash1Position+1)
@@ -105,22 +108,21 @@ Describe "Test-IshSession" -Tags "Read" {
 			$hostname = $webServicesBaseUrl.Substring($slash2Position+1,$slash3Position-$slash2Position-1)
 			$computername = $hostname.Substring(0,$hostname.IndexOf("."))
 			$webServicesBaseUrlToComputerName = $webServicesBaseUrl.Replace($hostname,$computername)
-			Test-IshSession -WsBaseUrl $webServicesBaseUrlToComputerName -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors | Should Be $true
+			Test-IshSession -WsBaseUrl $webServicesBaseUrlToComputerName -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors -WarningAction Ignore | Should -Be $true
 		}
 	}
 
 	Context "New-IshSession ExplicitIssuer" {
 		It "Parameter WsTrustIssuerUrl and WsTrustIssuerMexUrl are using full hostname" {
-			Test-IshSession -WsBaseUrl $webServicesBaseUrl -WsTrustIssuerUrl $wsTrustIssuerUrl -WsTrustIssuerMexUrl $wsTrustIssuerMexUrl -IshUserName $ishUserName -IshPassword $ishPassword | Should BeExactly $true
+			Test-IshSession -WsBaseUrl $webServicesBaseUrl -WsTrustIssuerUrl $wsTrustIssuerUrl -WsTrustIssuerMexUrl $wsTrustIssuerMexUrl -IshUserName $ishUserName -IshPassword $ishPassword | Should -BeExactly $true
 		}
-		It "Parameter WsTrustIssuerUrl and WsTrustIssuerMexUrl are using localhost" -skip {
-			Test-IshSession -WsBaseUrl $localWebServicesBaseUrl -WsTrustIssuerUrl $localWsTrustIssuerUrl -WsTrustIssuerMexUrl $localWsTrustIssuerMexUrl -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors | Should BeExactly $true
+		It "Parameter WsTrustIssuerUrl and WsTrustIssuerMexUrl are using localhost" -Skip {
+			Test-IshSession -WsBaseUrl $localWebServicesBaseUrl -WsTrustIssuerUrl $localWsTrustIssuerUrl -WsTrustIssuerMexUrl $localWsTrustIssuerMexUrl -IshUserName $ishUserName -IshPassword $ishPassword -IgnoreSslPolicyErrors -WarningAction Ignore | Should -BeExactly $true
 		}
 	}
 
 }
 
-	
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/CompareIshTypeFieldDefinition.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/CompareIshTypeFieldDefinition.Tests.ps1
@@ -1,8 +1,11 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Compare-IshTypeFieldDefinition"
-$tempFilePath1 = (New-TemporaryFile).FullName
-$tempFilePath2 = (New-TemporaryFile).FullName
+BeforeAll {
+	$cmdletName = "Compare-IshTypeFieldDefinition"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+	
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+	$tempFilePath1 = (New-TemporaryFile).FullName
+	$tempFilePath2 = (New-TemporaryFile).FullName
 $tridkXmlSetupUser1Content = @"
 <?xml version="1.0"?><?xml-stylesheet href="full.export.xsl" type="text/xsl"?><!-- InfoShare Author 3.5.0 --><tridk:setup xml:lang="EN" xmlns:tridk="urn:trisoft.be:Tridk:Setup:1.0" tridk:version="120.11.0.3215"><tridk:cardtypes><!-- General cardtypes --><tridk:cardtype tridk:exportmode="cascade" tridk:element="USER" tridk:metatype="usercard"><tridk:displaydefinition><tridk:label>User</tridk:label><tridk:description/></tridk:displaydefinition><tridk:fielddefinition><tridk:cardtypefield tridk:element="CREATED-ON" tridk:userdefined="no"><tridk:sequence tridk:value="5"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="DELETE-ACCESS" tridk:userdefined="no"><tridk:sequence tridk:value="11"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="FUSERGROUP" tridk:userdefined="yes"><tridk:sequence tridk:value="1"/><tridk:memberdefinition><tridk:member tridk:element="CTUSERGROUP"/></tridk:memberdefinition></tridk:cardtypefield><tridk:cardtypefield tridk:element="NAME" tridk:userdefined="no"><tridk:sequence tridk:value="2"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="OSUSERLEFT" tridk:userdefined="no"><tridk:sequence tridk:value="17"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="PASSWORD" tridk:userdefined="no"><tridk:sequence tridk:value="52"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="USERNAME" tridk:userdefined="no"><tridk:sequence tridk:value="3"/></tridk:cardtypefield></tridk:fielddefinition></tridk:cardtype></tridk:cardtypes><tridk:fields><tridk:field tridk:exportmode="cascade" tridk:element="CREATED-ON"><tridk:displaydefinition>	<tridk:label>Creation Date</tridk:label><tridk:description>Used on all cards to indicate the date that the object was created</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typedate><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typedate></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="INDEX"/><tridk:class tridk:element="VCLASSDISPLAYHISTORY"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="DELETE-ACCESS"><tridk:displaydefinition><tridk:label>Delete Access</tridk:label><tridk:description>User roles required in order to delete the object</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelov tridk:element="DUSERGROUP"><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="999999"/></tridk:typelov></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="SECURITY"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="FUSERGROUP"><tridk:displaydefinition><tridk:label>Usergroup</tridk:label><tridk:description>Used on all card types. On the USER card type the field indicates that the user has write/modify access to documents of this usergroup. On all other objects the field contains the usergroup that owns the object and can modify the object.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typecardreference><tridk:memberdefinedoncard tridk:value="no"/><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="999999"/></tridk:typecardreference></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="no"/><tridk:classdefinition><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/><tridk:class tridk:element="INDEX"/><tridk:class tridk:element="DOCUMENT"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="NAME"><tridk:displaydefinition><tridk:label>Label</tridk:label><tridk:description>Internal system field to hold the unique label of the object within its own object type.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelanguagedependentstring><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typelanguagedependentstring></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/><tridk:class tridk:element="DOCUMENT"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="OSUSERLEFT"><tridk:displaydefinition><tridk:label>OS-User</tridk:label><tridk:description>The username for windows NT authentication</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typestring><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typestring></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/></tridk:classdefinition></tridk:field>	<tridk:field tridk:exportmode="cascade" tridk:element="PASSWORD"><tridk:displaydefinition><tridk:label>Password</tridk:label><tridk:description>Encrypted password of the user.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelongtext><tridk:minnoofvalues tridk:value="0"/></tridk:typelongtext></tridk:typedefinition><tridk:public tridk:value="no"/><tridk:system tridk:value="yes"/><tridk:classdefinition/></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="USERNAME"><tridk:displaydefinition><tridk:label>User Name</tridk:label><tridk:description>The username of the user</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelov tridk:element="USERNAME"><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typelov></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/></tridk:classdefinition></tridk:field></tridk:fields></tridk:setup>
 "@
@@ -10,123 +13,124 @@ $tridkXmlSetupUser2Content = @"
 <?xml version="1.0"?><?xml-stylesheet href="full.export.xsl" type="text/xsl"?><!-- InfoShare Author 3.5.0 --><tridk:setup xml:lang="EN" xmlns:tridk="urn:trisoft.be:Tridk:Setup:1.0" tridk:version="120.11.0.3215"><tridk:cardtypes><!-- General cardtypes --><tridk:cardtype tridk:exportmode="cascade" tridk:element="USER" tridk:metatype="usercard"><tridk:displaydefinition><tridk:label>User</tridk:label><tridk:description/></tridk:displaydefinition><tridk:fielddefinition><tridk:cardtypefield tridk:element="DELETE-ACCESS" tridk:userdefined="no"><tridk:sequence tridk:value="11"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="FUSERGROUP" tridk:userdefined="yes"><tridk:sequence tridk:value="1"/><tridk:memberdefinition><tridk:member tridk:element="CTCONFIGURATION"/></tridk:memberdefinition></tridk:cardtypefield><tridk:cardtypefield tridk:element="NAME" tridk:userdefined="no"><tridk:sequence tridk:value="2"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="OSUSERRIGHT" tridk:userdefined="no"><tridk:sequence tridk:value="17"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="PASSWORD" tridk:userdefined="no"><tridk:sequence tridk:value="52"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="USERNAME" tridk:userdefined="no"><tridk:sequence tridk:value="3"/></tridk:cardtypefield></tridk:fielddefinition></tridk:cardtype></tridk:cardtypes><tridk:fields><tridk:field tridk:exportmode="cascade" tridk:element="CREATED-ON"><tridk:displaydefinition>	<tridk:label>Creation Date</tridk:label><tridk:description>Used on all cards to indicate the date that the object was created</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typedate><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typedate></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="INDEX"/><tridk:class tridk:element="VCLASSDISPLAYHISTORY"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="DELETE-ACCESS"><tridk:displaydefinition><tridk:label>Delete Access</tridk:label><tridk:description>User roles required in order to delete the object</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelov tridk:element="DUSERGROUP"><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="999999"/></tridk:typelov></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="SECURITY"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="FUSERGROUP"><tridk:displaydefinition><tridk:label>Usergroup</tridk:label><tridk:description>Used on all card types. On the USER card type the field indicates that the user has write/modify access to documents of this usergroup. On all other objects the field contains the usergroup that owns the object and can modify the object.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typecardreference><tridk:memberdefinedoncard tridk:value="no"/><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="999999"/></tridk:typecardreference></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="no"/><tridk:classdefinition><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/><tridk:class tridk:element="DOCUMENT"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="NAME"><tridk:displaydefinition><tridk:label>Label</tridk:label><tridk:description>Internal system field to hold the unique label of the object within its own object type.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelanguagedependentstring><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1000"/></tridk:typelanguagedependentstring></tridk:typedefinition><tridk:public tridk:value="no"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/><tridk:class tridk:element="DOCUMENT"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="OSUSERRIGHT"><tridk:displaydefinition><tridk:label>OS-User</tridk:label><tridk:description>The username for windows NT authentication</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typestring><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typestring></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/></tridk:classdefinition></tridk:field>	<tridk:field tridk:exportmode="cascade" tridk:element="PASSWORD"><tridk:displaydefinition><tridk:label>Password</tridk:label><tridk:description>Encrypted password of the user.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelongtext><tridk:minnoofvalues tridk:value="0"/></tridk:typelongtext></tridk:typedefinition><tridk:public tridk:value="no"/><tridk:system tridk:value="yes"/><tridk:classdefinition/></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="USERNAME"><tridk:displaydefinition><tridk:label>User Name</tridk:label><tridk:description>The username of the user</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelov tridk:element="USERNAME"><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typelov></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/></tridk:classdefinition></tridk:field></tridk:fields></tridk:setup>
 "@
 
+}
 
-try {
-
-Describe “Compare-IshTypeFieldDefinition" -Tags "Read" {
+Describe "Compare-IshTypeFieldDefinition" -Tags "Read" {
 	Context "Compare-IshTypeFieldDefinition with 2 IshTypeFieldDefinitions" {
-		$WarningPreference="SilentlyContinue"
-		$tridkXmlSetupUser1Content | Out-File $tempFilePath1
-		$referenceIshTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath1
-		$tridkXmlSetupUser2Content | Out-File $tempFilePath2
-		$differenceIshTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath2
-		$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions
+		BeforeAll {
+			$WarningPreference="SilentlyContinue"
+			$tridkXmlSetupUser1Content | Out-File $tempFilePath1
+			$referenceIshTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath1
+			$tridkXmlSetupUser2Content | Out-File $tempFilePath2
+			$differenceIshTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath2
+			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions
+		}
 		It "GetType().Name" {
-			$ishTypeFieldDefinitionCompares[0].GetType().Name | Should BeExactly "IshTypeFieldDefinitionCompare"
+			$ishTypeFieldDefinitionCompares[0].GetType().Name | Should -BeExactly "IshTypeFieldDefinitionCompare"
 		}
 		It "Parameter Left invalid" {
-			{ Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition "INVALIDREFERENCELIST" -RightIshTypeFieldDefinition "INVALIDDIFFERENCELIST" } | Should Throw
+			{ Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition "INVALIDREFERENCELIST" -RightIshTypeFieldDefinition "INVALIDDIFFERENCELIST" } | Should -Throw
 		}
 		It "Parameter Right invalid" {
-			{ Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition "INVALIDDIFFERENCELIST" } | Should Throw
+			{ Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition "INVALIDDIFFERENCELIST" } | Should -Throw
 		}
 		It "Parameter Left/Right using IncludeIdentical" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions -IncludeIdentical
-			$ishTypeFieldDefinitionCompares.Count | Should Be 9
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 9
 		}
 		It "Parameter Left/Right" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions
-			$ishTypeFieldDefinitionCompares.Count | Should Be 7  # =9entries-2equals
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 7  # =9entries-2equals
 		}
 		It "Parameter Left/Right using ExcludeDifferent" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions -ExcludeDifferent
-			$ishTypeFieldDefinitionCompares.Count | Should Be 3  # =9entries-2equals-2x2diff
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 3  # =9entries-2equals-2x2diff
 		}
 		It "Parameter Left/Right using ExcludeDifferent/ExcludeLeftUnique" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions -ExcludeDifferent -ExcludeLeftUnique
-			$ishTypeFieldDefinitionCompares.Count | Should Be 1  # =9entries-2equals-2x2diff-2left
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 1  # =9entries-2equals-2x2diff-2left
 		}
 		It "Parameter Left/Right using ExcludeDifferent/ExcludeRightUnique" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions -ExcludeDifferent -ExcludeRightUnique
-			$ishTypeFieldDefinitionCompares.Count | Should Be 2  # =9entries-2equals-2x2diff-1right
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 2  # =9entries-2equals-2x2diff-1right
 		}
 		It "Parameter Left/Right using IncludeIdentical/ExcludeDifferent/ExcludeLeftUnique/ExcludeRightUnique" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshTypeFieldDefinition $differenceIshTypeFieldDefinitions -IncludeIdentical -ExcludeDifferent -ExcludeLeftUnique -ExcludeRightUnique
-			$ishTypeFieldDefinitionCompares.Count | Should Be 2  # =9entries-2x2diff-2left-1right
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 2  # =9entries-2x2diff-2left-1right
 		}
 		# More tests possible for the IshTypeFieldDefinition properties
 		# Perhaps also test that there CardFields and TableFields present
 	}
-
 	Context "Compare-IshTypeFieldDefinition using IshSession" {
 		It "Parameter Left invalid" {
-			{ Compare-IshTypeFieldDefinition -LeftIshSession "INVALIDREFERENCEISHSESSION" -RightIshSession "INVALIDDIFFERENCEISHSESSION" } | Should Throw
+			{ Compare-IshTypeFieldDefinition -LeftIshSession "INVALIDREFERENCEISHSESSION" -RightIshSession "INVALIDDIFFERENCEISHSESSION" } | Should -Throw
 		}
 		It "Parameter Right invalid" {
-			{ Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession "INVALIDDIFFERENCEISHSESSION" } | Should Throw
+			{ Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession "INVALIDDIFFERENCEISHSESSION" } | Should -Throw
 		}
 		It "Parameter Left/Right same IshSession" {
-			{ Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession } | Should Not Throw
+			{ Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession } | Should -Not -Throw
 		}
 		It "Parameter Left/Right same IshSession using IncludeIdentical" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession -IncludeIdentical
-			$ishTypeFieldDefinitionCompares.Count -eq $ishSession.IshTypeFieldDefinition.Count | Should Be $true
+			$ishTypeFieldDefinitionCompares.Count -eq $ishSession.IshTypeFieldDefinition.Count | Should -Be $true
 		}
 		It "Parameter Left/Right same IshSession using ExcludeDifferent" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession -ExcludeDifferent
-			$ishTypeFieldDefinitionCompares.Count | Should Be 0
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 0
 		}
 		It "Parameter Left/Right same IshSession using ExcludeLeftUnique" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession -ExcludeLeftUnique
-			$ishTypeFieldDefinitionCompares.Count | Should Be 0
+			$ishTypeFieldDefinitionCompares.Count | Should -Be 0
 		}
 		It "Parameter Left/Right same IshSession using IncludeIdentical/ExcludeRightUnique" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession -IncludeIdentical -ExcludeRightUnique
-			$ishTypeFieldDefinitionCompares.Count -eq $ishSession.IshTypeFieldDefinition.Count | Should Be $true
+			$ishTypeFieldDefinitionCompares.Count -eq $ishSession.IshTypeFieldDefinition.Count | Should -Be $true
 		}
 		It "Parameter Left/Right same IshSession using IncludeIdentical/ExcludeDifferent/ExcludeLeftUnique/ExcludeRightUnique" {
 			$ishTypeFieldDefinitionCompares = Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshSession $ishSession -IncludeIdentical -ExcludeDifferent -ExcludeLeftUnique -ExcludeRightUnique
-			$ishTypeFieldDefinitionCompares.Count -eq $ishSession.IshTypeFieldDefinition.Count | Should Be $true
+			$ishTypeFieldDefinitionCompares.Count -eq $ishSession.IshTypeFieldDefinition.Count | Should -Be $true
 		}
 	}
-
 	Context "Compare-IshTypeFieldDefinition mixing IshSession and TriDKXmlSetupFilePath" {
-		$WarningPreference="SilentlyContinue"
-		$tridkXmlSetupUser1Content | Out-File $tempFilePath1
-		$referenceIshTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath1
+		BeforeAll {
+			$WarningPreference="SilentlyContinue"
+			$tridkXmlSetupUser1Content | Out-File $tempFilePath1
+			$referenceIshTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath1
+		}
 		It "Parameter Left is IshSession and Right is TriDKXmlSetupFilePath" {
-			(Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshTypeFieldDefinition $referenceIshTypeFieldDefinitions).Count -ge 460 | Should Be $true
+			(Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshTypeFieldDefinition $referenceIshTypeFieldDefinitions).Count -ge 460 | Should -Be $true
 		}
 		It "Parameter Left is IshSession and Right is TriDKXmlSetupFilePath using ExcludeDifferent" {
-			(Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -ExcludeDifferent).Count -ge 460 | Should Be $true
+			(Compare-IshTypeFieldDefinition -LeftIshSession $ishSession -RightIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -ExcludeDifferent).Count -ge 460 | Should -Be $true
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using IncludeIdentical" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -IncludeIdentical).Count -ge 460 | Should Be $true
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -IncludeIdentical).Count -ge 460 | Should -Be $true
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using ExcludeDifferent" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeDifferent).Count -ge 460 | Should Be $true
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeDifferent).Count -ge 460 | Should -Be $true
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using ExcludeLeftUnique" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeLeftUnique).Count -ge 460 | Should Be $true
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeLeftUnique).Count -ge 460 | Should -Be $true
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using ExcludeRightUnique" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeRightUnique).Count | Should Be 11
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeRightUnique).Count | Should -Be 11
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using ExcludeLeftUnique/ExcludeRightUnique" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeLeftUnique -ExcludeRightUnique).Count | Should Be 10
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeLeftUnique -ExcludeRightUnique).Count | Should -Be 10
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using ExcludeDifferent/ExcludeLeftUnique/ExcludeRightUnique" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeDifferent -ExcludeLeftUnique -ExcludeRightUnique).Count | Should Be 0
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -ExcludeDifferent -ExcludeLeftUnique -ExcludeRightUnique).Count | Should -Be 0
 		}
 		It "Parameter Left is TriDKXmlSetupFilePath and Right is IshSession using ExcludeDifferent/ExcludeLeftUnique/ExcludeRightUnique" {
-			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -IncludeIdentical -ExcludeDifferent -ExcludeLeftUnique -ExcludeRightUnique).Count | Should Be 0
+			(Compare-IshTypeFieldDefinition -LeftIshTypeFieldDefinition $referenceIshTypeFieldDefinitions -RightIshSession $ishSession -IncludeIdentical -ExcludeDifferent -ExcludeLeftUnique -ExcludeRightUnique).Count | Should -Be 0
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	try { Remove-Item $tempFilePath1 -Force } catch { }
 	try { Remove-Item $tempFilePath2 -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/GetIshSetting.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/GetIshSetting.Tests.ps1
@@ -1,105 +1,110 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshSetting"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshSetting"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshSetting" -Tags "Read" {
-	Context “Get-IshSetting ParameterGroup" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe "Get-IshSetting" -Tags "Read" {
+	Context "Get-IshSetting ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshSetting -IShSession "INVALIDISHSESSION" -FieldName "NAME" -FilePath "INVALIDFILEPATH" } | Should Throw
+			{ Get-IshSetting -IShSession "INVALIDISHSESSION" -FieldName "NAME" -FilePath "INVALIDFILEPATH" } | Should -Throw
 		}
 		It "Parameter FileName invalid" {
-			{ Get-IshSetting -IShSession $ishSession -FieldName "INVALIDFIELDNAME" -FilePath "INVALIDFILEPATH" } | Should Throw
+			{ Get-IshSetting -IShSession $ishSession -FieldName "INVALIDFIELDNAME" -FilePath "INVALIDFILEPATH" } | Should -Throw
 		}
 		It "Parameter FilePath invalid" {
-			{ Get-IshSetting -IShSession $ishSession -FieldName "NAME" -FilePath "INVALIDFILEPATH" } | Should Throw
+			{ Get-IshSetting -IShSession $ishSession -FieldName "NAME" -FilePath "INVALIDFILEPATH" } | Should -Throw
 		}
 	}
-
-	Context “Get-IshSetting ParameterGroup returns string object" {
+	Context "Get-IshSetting ParameterGroup returns string object" {
 		It "Parameter FieldName" {
 			$fieldValue = Get-IshSetting -IShSession $ishSession -FieldName "NAME"
-			$fieldValue.GetType().Name | Should BeExactly "String"
-			$fieldValue | Should Be "Configuration card"
+			$fieldValue.GetType().Name | Should -BeExactly "String"
+			$fieldValue | Should -Be "Configuration card"
 		}
 		It "Parameter ValueType" {
 			$fieldValue = Get-IshSetting -FieldName FISHSYSTEMRESOLUTION -ValueType Element
-			$fieldValue.StartsWith('VRES') | Should Be $true
+			$fieldValue.StartsWith('VRES') | Should -Be $true
 		}
 	}
-
-	Context “Get-IshSetting ParameterGroup returns string FileInfo object" {
-		# Create temp file path, but make sure it doesn't exist before calling Get-IshSetting
-		$tempFilePath = (New-TemporaryFile).FullName
-		Remove-Item $tempFilePath -Force
-		$fileInfo = Get-IshSetting -IShSession $ishSession -FieldName "NAME" -FilePath $tempFilePath
+	Context "Get-IshSetting ParameterGroup returns string FileInfo object" {
+		BeforeAll {
+			# Create temp file path, but make sure it doesn't exist before calling Get-IshSetting
+			$tempFilePath = (New-TemporaryFile).FullName
+			Remove-Item $tempFilePath -Force
+			$fileInfo = Get-IshSetting -IShSession $ishSession -FieldName "NAME" -FilePath $tempFilePath
+		}
 		It "GetType().Name" {
-			$fileInfo.GetType().Name | Should BeExactly "FileInfo"
+			$fileInfo.GetType().Name | Should -BeExactly "FileInfo"
 		}
 		It "File Exists" {
-			$fileInfo.FullName -eq $tempFilePath | Should Be $true
-			Test-Path -Path $fileInfo.FullName | Should Be $true
+			$fileInfo.FullName -eq $tempFilePath | Should -Be $true
+			Test-Path -Path $fileInfo.FullName | Should -Be $true
 		}
 		It "file NAME is 'Configuration card'" {
-			(Get-Content $tempFilePath) | Should Be "Configuration card"
+			(Get-Content $tempFilePath) | Should -Be "Configuration card"
 		}
 	}
-
-	Context “Get-IshSetting ParameterGroup Force returns xml FileInfo object" {
-		# Create readonly temp file path, but make it gets overwritten with the -Force parameter
-		$tempFilePath = (New-TemporaryFile).FullName
-		Set-ItemProperty $tempFilePath -Name IsReadOnly -Value $true
-		$fileInfo = Get-IshSetting -IShSession $ishSession -FieldName "FISHBACKGROUNDTASKCONFIG" -FilePath $tempFilePath -Force
+	Context "Get-IshSetting ParameterGroup Force returns xml FileInfo object" {
+		BeforeAll {
+			# Create readonly temp file path, but make it gets overwritten with the -Force parameter
+			$tempFilePath = (New-TemporaryFile).FullName
+			Set-ItemProperty $tempFilePath -Name IsReadOnly -Value $true
+			$fileInfo = Get-IshSetting -IShSession $ishSession -FieldName "FISHBACKGROUNDTASKCONFIG" -FilePath $tempFilePath -Force
+		}
 		It "FISHBACKGROUNDTASKCONFIG is xml" {
 			$fileContent = Get-Content $tempFilePath
-			$fileContent -like "<infoShareBackgroundTaskConfig*" | Should Be $true
+			$fileContent -like "<infoShareBackgroundTaskConfig*" | Should -Be $true
 		}
 	}
-
 	Context "Get-IshSetting RequestedMetadataGroup returns IshFields object" {
-		$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FINBOXCONFIGURATION" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBACKGROUNDTASKCONFIG" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHCHANGETRACKERCONFIG" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHENRICHURI" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHEXTENSIONCONFIG" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHLCURI" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHPUBSTATECONFIG" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHSYSTEMRESOLUTION" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHTRANSJOBSTATECONFIG" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHWRITEOBJPLUGINCFG" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FSTATECONFIGURATION" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTRANSLATIONCONFIGURATION" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "MODIFIED-ON" |
-							 Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME"
+		BeforeAll {
+			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name "FINBOXCONFIGURATION" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHBACKGROUNDTASKCONFIG" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHCHANGETRACKERCONFIG" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHENRICHURI" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHEXTENSIONCONFIG" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHLCURI" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHPUBSTATECONFIG" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHSYSTEMRESOLUTION" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHTRANSJOBSTATECONFIG" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHWRITEOBJPLUGINCFG" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FSTATECONFIGURATION" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "FTRANSLATIONCONFIGURATION" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "MODIFIED-ON" |
+								Set-IshRequestedMetadataField -IshSession $ishSession -Name "NAME"
+		}
 		It "Parameter IshSession.DefaultRequestedMetadata=Descriptive" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "Descriptive"
 			$ishFields = Get-IshSetting -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
-			$ishFields.GetType().Name | Should BeExactly "Object[]"
-			$ishFields.Length | Should Be 14
-			(Get-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "NAME" -Level None) | Should Be "Configuration card"
+			$ishFields.GetType().Name | Should -BeExactly "Object[]"
+			$ishFields.Length | Should -Be 14
+			(Get-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "NAME" -Level None) | Should -Be "Configuration card"
 		}
 		It "Parameter IshSession.DefaultRequestedMetadata=Basic" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "Basic"
 			$ishFields = Get-IshSetting -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
-			$ishFields.GetType().Name | Should BeExactly "Object[]"
+			$ishFields.GetType().Name | Should -BeExactly "Object[]"
 			$ishVersion = Get-IshVersion
 			$expectedIshFieldsLength = 19  # Minimal amount of basic fields since we have the (hardcoded) call since 13.0.0
 			# if($ishVersion.MajorVersion -eq 14 -and $ishVersion.RevisionVersion -eq 0) { $expectedIshFieldsLength = 22 } # 14.0.0, fields FISHCOLLECTIVESPACESCFG, FISHPREVIEWRESOLUTION(value), FISHPREVIEWRESOLUTION(element) were added
 			# if($ishVersion.MajorVersion -eq 14 -and $ishVersion.RevisionVersion -ge 1) { $expectedIshFieldsLength = 23 } # 14.0.1, field FISHANNOTATIONSTATECONFG was added
 			# if($ishVersion.MajorVersion -gt 14) { $expectedIshFieldsLength = 23 }
-			$ishFields.Length -ge $expectedIshFieldsLength | Should Be $true
-			(Get-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "NAME" -Level None) | Should Be "Configuration card"
+			$ishFields.Length -ge $expectedIshFieldsLength | Should -Be $true
+			(Get-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "NAME" -Level None) | Should -Be "Configuration card"
 		}
 		It "Parameter IshSession.DefaultRequestedMetadata=All" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "All"
 			$ishFields = Get-IshSetting -IshSession $ishSession -RequestedMetadata $requestedMetadata
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
-			$ishFields.GetType().Name | Should BeExactly "Object[]"
+			$ishFields.GetType().Name | Should -BeExactly "Object[]"
 			$ishVersion = Get-IshVersion
 			$expectedIshFieldsLength = 31  # Minimal amount of all fields since we have the (hardcoded) call since 13.0.0
 			# if($ishVersion.MajorVersion -le 13) { $expectedIshFieldsLength = 31 }
@@ -107,14 +112,14 @@ Describe “Get-IshSetting" -Tags "Read" {
 			# if($ishVersion.MajorVersion -eq 14 -and $ishVersion.RevisionVersion -ge 1) { $expectedIshFieldsLength = 35 } # 14.0.1, field FISHANNOTATIONSTATECONFG was added
 			# if($ishVersion.MajorVersion -eq 14 -and $ishVersion.RevisionVersion -ge 4) { $expectedIshFieldsLength = 37 } # 14.0.4, field FISHENABLESMARTTAGGING was added
 			# if($ishVersion.MajorVersion -gt 14) { $expectedIshFieldsLength = 35 }
-			$ishFields.Length -ge $expectedIshFieldsLength | Should Be $true
-			(Get-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "NAME" -Level None) | Should Be "Configuration card"
+			$ishFields.Length -ge $expectedIshFieldsLength | Should -Be $true
+			(Get-IshMetadataField -IshSession $ishSession -IshField $ishFields -Name "NAME" -Level None) | Should -Be "Configuration card"
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	try { Remove-Item $tempFilePath -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/GetIshTimeZone.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/GetIshTimeZone.Tests.ps1
@@ -1,56 +1,59 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshTimeZone"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshTimeZone"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Get-IshTimeZone" -Tags "Read" {
-	Context “Get-IshTimeZone Parameters" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe "Get-IshTimeZone" -Tags "Read" {
+	Context "Get-IshTimeZone Parameters" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshTimeZone -IShSession "INVALIDISHSESSION" -Count 2 } | Should Throw
+			{ Get-IshTimeZone -IShSession "INVALIDISHSESSION" -Count 2 } | Should -Throw
 		}
 		It "Parameter Count invalid" {
-			{ Get-IshTimeZone -IShSession $ishSession -Count "INVALIDCOUNT" } | Should Throw
+			{ Get-IshTimeZone -IShSession $ishSession -Count "INVALIDCOUNT" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshTimeZone returns IshApplicationSetting (single) object" {
-		$ishApplicationSetting = Get-IshTimeZone -IShSession $ishSession
+		BeforeAll {
+			$ishApplicationSetting = Get-IshTimeZone -IShSession $ishSession
+		}
 		It "GetType()" {
-			$ishApplicationSetting.GetType().Name | Should BeExactly "IshApplicationSetting"
+			$ishApplicationSetting.GetType().Name | Should -BeExactly "IshApplicationSetting"
 		}
 		It "IshApplicationSetting.TimeElapsedDbServer" {
-			$ishApplicationSetting.TimeElapsedDbServer -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSetting.TimeElapsedDbServer -ge 0 | Should -Not -BeNullOrEmpty
 		}
 		It "IshApplicationSetting.TimeElapsedAppServer" {
-			$ishApplicationSetting.TimeElapsedAppServer -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSetting.TimeElapsedAppServer -ge 0 | Should -Not -BeNullOrEmpty
 		}
 		It "IshApplicationSetting.TimeElapsedWsCall" {
-			$ishApplicationSetting.TimeElapsedWsCall -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSetting.TimeElapsedWsCall -ge 0 | Should -Not -BeNullOrEmpty
 		}
 		It "IshApplicationSetting.TimeZoneDisplayName" {
-			$ishApplicationSetting.TimeZoneDisplayName.Length -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSetting.TimeZoneDisplayName.Length -ge 0 | Should -Not -BeNullOrEmpty
 		}
 		It "IshApplicationSetting.TimeZoneUtcOffset" {
-			$ishApplicationSetting.TimeZoneUtcOffset -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSetting.TimeZoneUtcOffset -ge 0 | Should -Not -BeNullOrEmpty
 		}
 		It "IshApplicationSetting.TimeZoneIsdaylightsavingtime" {
-			{ $ishApplicationSetting.TimeZoneIsdaylightsavingtime } | Should Not Throw
+			{ $ishApplicationSetting.TimeZoneIsdaylightsavingtime } | Should -Not -Throw
 		}
 		It "IshApplicationSetting.AppServerComputerName" {
-			$ishApplicationSetting.AppServerComputerName.Length -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSetting.AppServerComputerName.Length -ge 0 | Should -Not -BeNullOrEmpty
 		}
 	}
-
 	Context "Get-IshTimeZone returns IshApplicationSettings (plural) object" {
 		It "Parameter IshSession implicit" {
 			$ishApplicationSettings = Get-IshTimeZone -IShSession $ishSession -Count 2
-			$ishApplicationSettings.GetType().Name | Should BeExactly "IshApplicationSettings"
-			$ishApplicationSettings.TimeZoneId -ge 0 | Should Not BeNullOrEmpty
+			$ishApplicationSettings.GetType().Name | Should -BeExactly "IshApplicationSettings"
+			$ishApplicationSettings.TimeZoneId -ge 0 | Should -Not -BeNullOrEmpty
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/GetIshTypeFieldDefinition.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Settings/GetIshTypeFieldDefinition.Tests.ps1
@@ -1,98 +1,100 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshTypeFieldDefinition"
-$tempFilePath = (New-TemporaryFile).FullName
+BeforeAll {
+	$cmdletName = "Get-IshTypeFieldDefinition"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+	
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+	$tempFilePath = (New-TemporaryFile).FullName
 $tridkXmlSetupUserContent = @"
 <?xml version="1.0"?><?xml-stylesheet href="full.export.xsl" type="text/xsl"?><!-- InfoShare Author 3.5.0 --><tridk:setup xml:lang="EN" xmlns:tridk="urn:trisoft.be:Tridk:Setup:1.0" tridk:version="120.11.0.3215"><tridk:cardtypes><!-- General cardtypes --><tridk:cardtype tridk:exportmode="cascade" tridk:element="USER" tridk:metatype="usercard"><tridk:displaydefinition><tridk:label>User</tridk:label><tridk:description/></tridk:displaydefinition><tridk:fielddefinition><tridk:cardtypefield tridk:element="CREATED-ON" tridk:userdefined="no"><tridk:sequence tridk:value="5"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="DELETE-ACCESS" tridk:userdefined="no"><tridk:sequence tridk:value="11"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="FUSERGROUP" tridk:userdefined="yes"><tridk:sequence tridk:value="1"/><tridk:memberdefinition><tridk:member tridk:element="CTUSERGROUP"/></tridk:memberdefinition></tridk:cardtypefield><tridk:cardtypefield tridk:element="NAME" tridk:userdefined="no"><tridk:sequence tridk:value="2"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="OSUSER" tridk:userdefined="no"><tridk:sequence tridk:value="17"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="PASSWORD" tridk:userdefined="no"><tridk:sequence tridk:value="52"/></tridk:cardtypefield><tridk:cardtypefield tridk:element="USERNAME" tridk:userdefined="no"><tridk:sequence tridk:value="3"/></tridk:cardtypefield></tridk:fielddefinition></tridk:cardtype></tridk:cardtypes><tridk:fields><tridk:field tridk:exportmode="cascade" tridk:element="CREATED-ON"><tridk:displaydefinition>	<tridk:label>Creation Date</tridk:label><tridk:description>Used on all cards to indicate the date that the object was created</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typedate><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typedate></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="INDEX"/><tridk:class tridk:element="VCLASSDISPLAYHISTORY"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="DELETE-ACCESS"><tridk:displaydefinition><tridk:label>Delete Access</tridk:label><tridk:description>User roles required in order to delete the object</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelov tridk:element="DUSERGROUP"><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="999999"/></tridk:typelov></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="SECURITY"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="FUSERGROUP"><tridk:displaydefinition><tridk:label>Usergroup</tridk:label><tridk:description>Used on all card types. On the USER card type the field indicates that the user has write/modify access to documents of this usergroup. On all other objects the field contains the usergroup that owns the object and can modify the object.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typecardreference><tridk:memberdefinedoncard tridk:value="no"/><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="999999"/></tridk:typecardreference></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="no"/><tridk:classdefinition><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/><tridk:class tridk:element="INDEX"/><tridk:class tridk:element="DOCUMENT"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="NAME"><tridk:displaydefinition><tridk:label>Label</tridk:label><tridk:description>Internal system field to hold the unique label of the object within its own object type.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelanguagedependentstring><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typelanguagedependentstring></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/><tridk:class tridk:element="DOCUMENT"/></tridk:classdefinition></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="OSUSER"><tridk:displaydefinition><tridk:label>OS-User</tridk:label><tridk:description>The username for windows NT authentication</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typestring><tridk:minnoofvalues tridk:value="0"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typestring></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/></tridk:classdefinition></tridk:field>	<tridk:field tridk:exportmode="cascade" tridk:element="PASSWORD"><tridk:displaydefinition><tridk:label>Password</tridk:label><tridk:description>Encrypted password of the user.</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelongtext><tridk:minnoofvalues tridk:value="0"/></tridk:typelongtext></tridk:typedefinition><tridk:public tridk:value="no"/><tridk:system tridk:value="yes"/><tridk:classdefinition/></tridk:field><tridk:field tridk:exportmode="cascade" tridk:element="USERNAME"><tridk:displaydefinition><tridk:label>User Name</tridk:label><tridk:description>The username of the user</tridk:description></tridk:displaydefinition><tridk:typedefinition><tridk:typelov tridk:element="USERNAME"><tridk:minnoofvalues tridk:value="1"/><tridk:maxnoofvalues tridk:value="1"/></tridk:typelov></tridk:typedefinition><tridk:public tridk:value="yes"/><tridk:system tridk:value="yes"/><tridk:classdefinition><tridk:class tridk:element="GENERAL"/><tridk:class tridk:element="NEW"/><tridk:class tridk:element="MODIFY"/></tridk:classdefinition></tridk:field></tridk:fields></tridk:setup>
 "@
 
-try {
+}
 
-Describe “Get-IshTypeFieldDefinition" -Tags "Read" {
+Describe "Get-IshTypeFieldDefinition" -Tags "Read" {
 	Context "Get-IshTypeFieldDefinition without IshSession/TriDKXmlSetupFilePath loads latest resource entry" {
-		$ishTypeFieldDefinitions = Get-IshTypeFieldDefinition
+		BeforeAll {
+			$ishTypeFieldDefinitions = Get-IshTypeFieldDefinition
+		}
 		It "GetType().Name" {
-			$ishTypeFieldDefinitions[0].GetType().Name | Should BeExactly "IshTypeFieldDefinition"
+			$ishTypeFieldDefinitions[0].GetType().Name | Should -BeExactly "IshTypeFieldDefinition"
 		}
 		It "ishTypeFieldDefinitions[0].ISHType" {
-			$ishTypeFieldDefinitions[0].ISHType | Should Not BeNullOrEmpty
+			$ishTypeFieldDefinitions[0].ISHType | Should -Not -BeNullOrEmpty
 		}
 		It "ishTypeFieldDefinitions[0].Level" {
-			$ishTypeFieldDefinitions[0].Level | Should Not BeNullOrEmpty
+			$ishTypeFieldDefinitions[0].Level | Should -Not -BeNullOrEmpty
 		}
 		It "ishTypeFieldDefinitions[0].Name" {
-			$ishTypeFieldDefinitions[0].Name | Should Not BeNullOrEmpty
+			$ishTypeFieldDefinitions[0].Name | Should -Not -BeNullOrEmpty
 		}
 		It "ishTypeFieldDefinitions[0].DataType" {
-			$ishTypeFieldDefinitions[0].DataType | Should Not BeNullOrEmpty
+			$ishTypeFieldDefinitions[0].DataType | Should -Not -BeNullOrEmpty
 		}
 		It "FXYEDITOR is not a standard field for <13.0.x" {
 			# Making sure the implicit IshSession stored in SessionState is temporarily removed
 			$restoreIshSession=$executioncontext.SessionState.PSVariable.GetValue("ISHRemoteSessionStateIshSession")
 			$executioncontext.SessionState.PSVariable.Set("ISHRemoteSessionStateIshSession", $null)
-			(Get-IshTypeFieldDefinition | Where-Object -Property Name -EQ -Value "FXYEDITOR").Count | Should Be 0
+			(Get-IshTypeFieldDefinition | Where-Object -Property Name -EQ -Value "FXYEDITOR").Count | Should -Be 0
 			$executioncontext.SessionState.PSVariable.Set("ISHRemoteSessionStateIshSession", $restoreIshSession)
 		}
 		# More tests required for the IshTypeFieldDefinition properties
 		# Also test that there CardFields and TableFields present
 	}
-
 	Context "Get-IshTypeFieldDefinition without IshSession only TriDKXmlSetupFilePath" {
 		It "Parameter TriDKXmlSetupFilePath invalid" {
-			{ Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath "INVALIDFILEPATH" } | Should Throw
+			{ Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath "INVALIDFILEPATH" } | Should -Throw
 		}
 		It "Parameter TriDKXmlSetup without IshSession" {
 			$WarningPreference="SilentlyContinue"
 			$tridkXmlSetupUserContent | Out-File $tempFilePath
 			$ishTypeFieldDefinitions = Get-IshTypeFieldDefinition -TriDKXmlSetupFilePath $tempFilePath
-			$ishTypeFieldDefinitions.Count | Should Be 6
+			$ishTypeFieldDefinitions.Count | Should -Be 6
 		}
 	}
-
-	Context “Get-IshTypeFieldDefinition with IshSession loads matching resource entry or Settings25" {
+	Context "Get-IshTypeFieldDefinition with IshSession loads matching resource entry or Settings25" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshTypeFieldDefinition -IShSession "INVALIDISHSESSION" } | Should Throw
+			{ Get-IshTypeFieldDefinition -IShSession "INVALIDISHSESSION" } | Should -Throw
 		}
 		It "IshSession.IshTypeFieldDefinition[0].GetType().Name" {
 			Get-IshTypeFieldDefinition -IshSession $ishSession
-			$ishSession.IshTypeFieldDefinition[0].GetType().Name | Should BeExactly "IshTypeFieldDefinition"
+			$ishSession.IshTypeFieldDefinition[0].GetType().Name | Should -BeExactly "IshTypeFieldDefinition"
 		}
 		It "Table ISHBackgroundTask (since 13.0.2)" {
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Level -EQ 'Task').Count | Should Be 15
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Level -EQ 'History').Count | Should Be 8
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property AllowOnRead -EQ $true).Count | Should Be 23 # all columns are allowed to be read
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property AllowOnCreate -EQ $false).Count | Should Be 23 # all columns are explicit api parameters and cannot be set over metadata
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property IsMultiValue -EQ $false).Count | Should Be 23 # all columns are single value
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property IsSystem -EQ $true).Count | Should Be 23 # all columns are system columns
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Name -EQ 'STATUS').DataSource | Should Be 'DBACKGROUNDTASKSTATUS'
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Name -EQ 'USERID').DataSource | Should Be 'USERNAME'
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Level -EQ 'Task').Count | Should -Be 15
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Level -EQ 'History').Count | Should -Be 8
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property AllowOnRead -EQ $true).Count | Should -Be 23 # all columns are allowed to be read
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property AllowOnCreate -EQ $false).Count | Should -Be 23 # all columns are explicit api parameters and cannot be set over metadata
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property IsMultiValue -EQ $false).Count | Should -Be 23 # all columns are single value
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property IsSystem -EQ $true).Count | Should -Be 23 # all columns are system columns
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Name -EQ 'STATUS').DataSource | Should -Be 'DBACKGROUNDTASKSTATUS'
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHBackgroundTask' | Where-Object -Property Name -EQ 'USERID').DataSource | Should -Be 'USERNAME'
 		}
 		It "Table ISHEvent" {
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property Level -EQ 'Progress').Count | Should Be 11
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property Level -EQ 'Detail').Count | Should Be 12
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property AllowOnRead -EQ $true).Count | Should Be 23 # all columns are allowed to be read
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property AllowOnCreate -EQ $false).Count | Should Be 23 # all columns are explicit api parameters and cannot be set over metadata
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property IsMultiValue -EQ $false).Count | Should Be 23 # all columns are single value
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property IsSystem -EQ $true).Count | Should Be 23 # all columns are system columns
-			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property Name -EQ 'USERID').DataSource | Should Be 'USERNAME'
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property Level -EQ 'Progress').Count | Should -Be 11
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property Level -EQ 'Detail').Count | Should -Be 12
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property AllowOnRead -EQ $true).Count | Should -Be 23 # all columns are allowed to be read
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property AllowOnCreate -EQ $false).Count | Should -Be 23 # all columns are explicit api parameters and cannot be set over metadata
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property IsMultiValue -EQ $false).Count | Should -Be 23 # all columns are single value
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property IsSystem -EQ $true).Count | Should -Be 23 # all columns are system columns
+			(Get-IshTypeFieldDefinition -IshSession $ishSession | Where-Object -Property ISHType -EQ 'ISHEvent' | Where-Object -Property Name -EQ 'USERID').DataSource | Should -Be 'USERNAME'
 		}
 	}
-
 	Context "Get-IshTypeFieldDefinition with IshSession/TriDKXmlSetupFilePath loads if ServerVersion<13.0.0" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshTypeFieldDefinition -IShSession "INVALIDISHSESSION" -TriDKXmlSetupFilePath "INVALIDFILEPATH" } | Should Throw
+			{ Get-IshTypeFieldDefinition -IShSession "INVALIDISHSESSION" -TriDKXmlSetupFilePath "INVALIDFILEPATH" } | Should -Throw
 		}
 	}
-
     Context "Get-IshTypeFieldDefinition and Metadata bound fields" {
-        $typeDefinitions = Get-IshTypeFieldDefinition -IshSession $ishSession
-
+		BeforeAll {
+        	$typeDefinitions = Get-IshTypeFieldDefinition -IshSession $ishSession
+		}
 		It "Check AllowOnSmartTagging not null, empty and boolean"{
 			# Initially test was 14s long doing a 'foreach($typeDefinition in $typeDefinitions)', now testing the first array entry
 			if ($typeDefinitions.Length -gt 0)
 			{
-				$typeDefinitions[0].AllowOnSmartTagging | Should Not BeNullOrEmpty
-				$typeDefinitions[0].AllowOnSmartTagging | Should BeOfType System.Boolean
+				$typeDefinitions[0].AllowOnSmartTagging | Should -Not -BeNullOrEmpty
+				$typeDefinitions[0].AllowOnSmartTagging | Should -BeOfType System.Boolean
 			}
         }
 		It "Check Metadata bound field - if configured in Extension XML settings"{
@@ -101,30 +103,29 @@ Describe “Get-IshTypeFieldDefinition" -Tags "Read" {
 			{
 				foreach($typeDefinitionMetadataBinding in $typeDefinitionsMetadataBinding)
 				{
-					$typeDefinitionMetadataBinding.DataSource | Should Not BeNullOrEmpty
-					$typeDefinitionMetadataBinding.ReferenceMetadataBinding | Should Not BeNullOrEmpty
-					($typeDefinitionMetadataBinding.DataSource -eq $typeDefinitionMetadataBinding.ReferenceMetadataBinding) | Should Be $true
+					$typeDefinitionMetadataBinding.DataSource | Should -Not -BeNullOrEmpty
+					$typeDefinitionMetadataBinding.ReferenceMetadataBinding | Should -Not -BeNullOrEmpty
+					($typeDefinitionMetadataBinding.DataSource -eq $typeDefinitionMetadataBinding.ReferenceMetadataBinding) | Should -Be $true
 				}
 			}
 		}
     }
-    
     Context "IshTypeFieldDefinition - check properties" {
         $typeDefinitions = Get-IshTypeFieldDefinition -IshSession $ishSession
         
         It "Check CRUST, MM and SDB length"{
             if ($typeDefinitions.Length -gt 0)
 			{
-				$typeDefinitions[0].CRUST.Length | Should Be 5
-				$typeDefinitions[0].MM.Length | Should Be 2
-				$typeDefinitions[0].SDB.Length | Should Be 3
+				$typeDefinitions[0].CRUST.Length | Should -Be 5
+				$typeDefinitions[0].MM.Length | Should -Be 2
+				$typeDefinitions[0].SDB.Length | Should -Be 3
             }
         }
     }
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	try { Remove-Item $tempFilePath -Force } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/User/AddIshUser.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/User/AddIshUser.Tests.ps1
@@ -1,17 +1,17 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshUser"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshUser"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Add-IshUser" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
 	Context "Add-IshUser ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshUser -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERNAME" } | Should Throw
+			{ Add-IshUser -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERNAME" } | Should -Throw
 		}
 	}
-
 	Context "Add-IshUser ParameterGroup" {
 		It "GetType().Name" {
 			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
@@ -19,9 +19,9 @@ Describe "Add-IshUser" -Tags "Create" {
                          Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
                          Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
 			$ishObject = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-			$ishObject.GetType().Name | Should BeExactly "IshUser"
-			$ishObject.Count | Should Be 1
-			(ConvertTo-Json $ishObject).Length -gt 2 | Should Be $true
+			$ishObject.GetType().Name | Should -BeExactly "IshUser"
+			$ishObject.Count | Should -Be 1
+			(ConvertTo-Json $ishObject).Length -gt 2 | Should -Be $true
 		}
 		It "Parameter Metadata" {
 			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
@@ -29,8 +29,8 @@ Describe "Add-IshUser" -Tags "Create" {
                         Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
                         Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
 			$ishObject = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-			$ishObject.Count | Should Be 1
-			$ishObject.IshRef -Like "VUSER*" | Should Be $true
+			$ishObject.Count | Should -Be 1
+			$ishObject.IshRef -Like "VUSER*" | Should -Be $true
 		}
 		It "Parameter Metadata return descriptive metadata" {
 			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
@@ -38,15 +38,15 @@ Describe "Add-IshUser" -Tags "Create" {
                         Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
                         Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
 			$ishObject = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERLANGUAGE -Level None -ValueType Element).Length -gt 1 | Should Be $true # added user field by element name
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERLANGUAGE -Level None -ValueType Value).Length -gt 1 | Should Be $true # added user field by element name, value added by AddDescriptiveFields
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FUSERGROUP -Level None -ValueType Element).Length -gt 1 | Should Be $true # added user field by element name
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FUSERGROUP -Level None -ValueType Value).Length -gt 1 | Should Be $true # added user field by element name, value added by AddDescriptiveFields
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name USERNAME -Level None).Length -gt 1 | Should Be $true
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.username.Length -ge 1 | Should Be $true 
-			$ishObject.fishusertype.Length -ge 1 | Should Be $true 
-			$ishObject.fishusertype_none_element.StartsWith('VUSERTYPE') | Should Be $true 
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERLANGUAGE -Level None -ValueType Element).Length -gt 1 | Should -Be $true # added user field by element name
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERLANGUAGE -Level None -ValueType Value).Length -gt 1 | Should -Be $true # added user field by element name, value added by AddDescriptiveFields
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FUSERGROUP -Level None -ValueType Element).Length -gt 1 | Should -Be $true # added user field by element name
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FUSERGROUP -Level None -ValueType Value).Length -gt 1 | Should -Be $true # added user field by element name, value added by AddDescriptiveFields
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name USERNAME -Level None).Length -gt 1 | Should -Be $true
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.username.Length -ge 1 | Should -Be $true 
+			$ishObject.fishusertype.Length -ge 1 | Should -Be $true 
+			$ishObject.fishusertype_none_element.StartsWith('VUSERTYPE') | Should -Be $true 
 		}
 		It "Parameter Metadata StrictMetadataPreference=Off with INVALIDFIELDNAME" {
 			$strictMetadataPreference = $ishSession.StrictMetadataPreference
@@ -60,7 +60,7 @@ Describe "Add-IshUser" -Tags "Create" {
                         Set-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -Level None -Value "SomethingReadAccess"  |
                         Set-IshMetadataField -IshSession $ishSession -Name "OWNER" -Level None -Value "SomethingOwner" |
                         Set-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level None -Value "SomethingInvalidFieldName"
-			{ Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata } | Should Throw
+			{ Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata } | Should -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 		It "Parameter Metadata StrictMetadataPreference=Continue with many system fields" {
@@ -86,7 +86,7 @@ Describe "Add-IshUser" -Tags "Create" {
 						Set-IshMetadataField -IshSession $ishSession -Name "FISHPASSWORDHISTORY" -Level None -Value "NoHistory" | # RemoveSystemFields always removed upon Create since Kojak/13.0.0
 						Set-IshMetadataField -IshSession $ishSession -Name "FISHFAILEDATTEMPTS" -Level None -Value "10" | # RemoveSystemFields always removed upon Create since Kojak/13.0.0
 						Set-IshMetadataField -IshSession $ishSession -Name "FISHFAVORITES" -Level None -Value "23" # RemoveSystemFields always removed upon Create
-			{ Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata } | Should Not Throw
+			{ Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata } | Should -Not -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 		It "Parameter Metadata StrictMetadataPreference=Off with many system fields" {
@@ -116,64 +116,65 @@ Describe "Add-IshUser" -Tags "Create" {
 						  Set-IshMetadataField -IshSession $ishSession -Name "FISHPASSWORDHISTORY" -Level None -Value "NoHistory" | # RemoveSystemFields always removed upon Create since Kojak/13.0.0
 						  Set-IshMetadataField -IshSession $ishSession -Name "FISHFAILEDATTEMPTS" -Level None -Value "10"  # RemoveSystemFields always removed upon Create since Kojak/13.0.0
 			}
-			{ Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata } | Should Throw
+			{ Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata } | Should -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 	}
-
 	Context "Add-IshUser IshObjectsGroup" {
-	    $metadata = Set-IshMetadataField -IshSession $ishSession -Name FISHUSERLANGUAGE -Level None -ValueType Element -Value "VLANGUAGEEN" |
-                    Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
-                    Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
-		$ishObjectE = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
-		$ishObjectF = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
-		Remove-IshUser -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
-		Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (VUSERADD-ISHUSER20161012164716068A12/10/2016 16:47:16)."
+		BeforeAll {
+			$metadata = Set-IshMetadataField -IshSession $ishSession -Name FISHUSERLANGUAGE -Level None -ValueType Element -Value "VLANGUAGEEN" |
+						Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
+						Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+			Remove-IshUser -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
+			Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (VUSERADD-ISHUSER20161012164716068A12/10/2016 16:47:16)."
+		}
 		It "Parameter IshObject invalid" {
-			{ Add-IshUser -IShSession $ishSession -IshObject "INVALIDUSER" } | Should Throw
+			{ Add-IshUser -IShSession $ishSession -IshObject "INVALIDUSER" } | Should -Throw
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			$ishObjectA = $ishObjectA | Set-IshMetadataField -Name PASSWORD -Level None -Value "PasswordNotPutOnThePipeline"
 		    $ishObjects = Add-IshUser -IshObject $ishObjectA
 			$ishObjects | Remove-IshUser
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 		    $ishObjectB = $ishObjectB | Set-IshMetadataField -Name PASSWORD -Level None -Value "PasswordNotPutOnThePipeline"
 			$ishObjectC = $ishObjectC | Set-IshMetadataField -Name PASSWORD -Level None -Value "PasswordNotPutOnThePipeline"
 			$ishObjects = Add-IshUser -IshObject @($ishObjectB,$ishObjectC)
 			$ishObjects | Remove-IshUser
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 		    $ishObjectD = $ishObjectD | Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "PasswordNotPutOnThePipeline"
 			$ishObjects = $ishObjectD | Add-IshUser -IshSession $ishSession
 			$ishObjects | Remove-IshUser -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 		    $ishObjectE = $ishObjectE | Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "PasswordNotPutOnThePipeline"
 			$ishObjectF = $ishObjectF | Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "PasswordNotPutOnThePipeline"
 			$ishObjects = @($ishObjectE,$ishObjectF) | Add-IshUser -IshSession $ishSession
 			$ishObjects | Remove-IshUser -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$users = Find-IshUser -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "USERNAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshUser -IshSession $ishSession -IshObject $users } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/User/GetIshUser.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/User/GetIshUser.Tests.ps1
@@ -1,42 +1,44 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Get-IshUser"
-try {
+BeforeAll {
+	$cmdletName = "Get-IshUser"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Get-IshUser" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
 	Context "Get-IshUser ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Get-IshUser -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERNAME" } | Should Throw
+			{ Get-IshUser -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERNAME" } | Should -Throw
 		}
 	}
-
 	Context "Get-IshUser ParameterGroup" {
-		$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
-		$metadata = Set-IshMetadataField -IshSession $ishSession -Name FISHUSERLANGUAGE -Level None -ValueType Element -Value "VLANGUAGEEN" |
-                    Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
-					Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
-		$ishObject = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+		BeforeAll {
+			$userName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
+			$metadata = Set-IshMetadataField -IshSession $ishSession -Name FISHUSERLANGUAGE -Level None -ValueType Element -Value "VLANGUAGEEN" |
+						Set-IshMetadataField -IshSession $ishSession -Name FUSERGROUP -Level None -ValueType Element -Value "VUSERGROUPDEFAULTDEPARTMENT" |
+						Set-IshMetadataField -IshSession $ishSession -Name PASSWORD -Level None -Value "SomethingSecret"
+			$ishObject = Add-IshUser -IshSession $ishSession -Name $userName -Metadata $metadata
+		}
 		It "Parameter IshSession Implicit" {
 			$ishObject = Get-IshUser -Id $ishObject.IshRef
-			$ishObject.GetType().Name | Should BeExactly "IshUser"
-			$ishObject.Count | Should Be 1
+			$ishObject.GetType().Name | Should -BeExactly "IshUser"
+			$ishObject.Count | Should -Be 1
 		}
 		It "Parameter Metadata StrictMetadataPreference=Off with PASSWORD" {
 			$strictMetadataPreference = $ishSession.StrictMetadataPreference
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name PASSWORD -Level None
 			$ishSession.StrictMetadataPreference = "Off"
-			{ Get-IshUser -IshSession $ishSession -Id $ishObject.IshRef -RequestedMetadata $requestedMetadata } | Should Throw
+			{ Get-IshUser -IshSession $ishSession -Id $ishObject.IshRef -RequestedMetadata $requestedMetadata } | Should -Throw
 			$ishSession.StrictMetadataPreference = "Continue"
-			{ Get-IshUser -IshSession $ishSession -Id $ishObject.IshRef -RequestedMetadata $requestedMetadata } | Should Not Throw
+			{ Get-IshUser -IshSession $ishSession -Id $ishObject.IshRef -RequestedMetadata $requestedMetadata } | Should -Not -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 		It "Parameter Metadata StrictMetadataPreference=Continue with PASSWORD" {
 			$strictMetadataPreference = $ishSession.StrictMetadataPreference
 			$requestedMetadata = Set-IshRequestedMetadataField -IshSession $ishSession -Name PASSWORD -Level None
 			$ishSession.StrictMetadataPreference = "Continue"
-			{ Get-IshUser -IshSession $ishSession -Id $ishObject.IshRef -RequestedMetadata $requestedMetadata } | Should Not Throw
+			{ Get-IshUser -IshSession $ishSession -Id $ishObject.IshRef -RequestedMetadata $requestedMetadata } | Should -Not -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 		It "Parameter IshSession.DefaultRequestedMetadata=Descriptive on My-Metadata" {
@@ -44,31 +46,31 @@ Describe "Get-IshUser" -Tags "Create" {
 			$ishSession.DefaultRequestedMetadata = "Descriptive"
 			$ishObject = Get-IshUser -IshSession $ishSession
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
-			$ishObject.GetType().Name | Should BeExactly "IshUser"
-			$ishObject.IshField.Length | Should Be 10
+			$ishObject.GetType().Name | Should -BeExactly "IshUser"
+			$ishObject.IshField.Length | Should -Be 10
 		}
 		It "Parameter IshSession.DefaultRequestedMetadata=Basic on My-Metadata" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "Basic"
 			$ishObject = Get-IshUser -IshSession $ishSession
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
-			$ishObject.GetType().Name | Should BeExactly "IshUser"
-			$ishObject.IshField.Length | Should Be 25
+			$ishObject.GetType().Name | Should -BeExactly "IshUser"
+			$ishObject.IshField.Length | Should -Be 25
 		}
 		It "Parameter IshSession.DefaultRequestedMetadata=All on My-Metadata" {
 			$oldDefaultRequestedMetadata = $ishSession.DefaultRequestedMetadata
 			$ishSession.DefaultRequestedMetadata = "All"
 			$ishObject = Get-IshUser -IshSession $ishSession
 			$ishSession.DefaultRequestedMetadata = $oldDefaultRequestedMetadata
-			$ishObject.GetType().Name | Should BeExactly "IshUser"
-			$ishObject.IshField.Length | Should Be 29
+			$ishObject.GetType().Name | Should -BeExactly "IshUser"
+			$ishObject.IshField.Length | Should -Be 29
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$users = Find-IshUser -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "USERNAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshUser -IshSession $ishSession -IshObject $users } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/UserGroup/AddIshUserGroup.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/UserGroup/AddIshUserGroup.Tests.ps1
@@ -1,42 +1,42 @@
-﻿Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshUserGroup"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshUserGroup"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
 
-Describe “Add-IshUserGroup" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
-	Context “Add-IshUserGroup ParameterGroup" {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
+
+Describe "Add-IshUserGroup" -Tags "Create" {
+	Context "Add-IshUserGroup ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshUserGroup -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERGROUPNAME" } | Should Throw
+			{ Add-IshUserGroup -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERGROUPNAME" } | Should -Throw
 		}
 	}
-
-	Context “Add-IshUserGroup ParameterGroup" {
+	Context "Add-IshUserGroup ParameterGroup" {
 		It "GetType().Name" {
 			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
 			$ishObject = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName
-			$ishObject.GetType().Name | Should BeExactly "IshUserGroup"
-			$ishObject.Count | Should Be 1
-			(ConvertTo-Json $ishObject).Length -gt 2 | Should Be $true
+			$ishObject.GetType().Name | Should -BeExactly "IshUserGroup"
+			$ishObject.Count | Should -Be 1
+			(ConvertTo-Json $ishObject).Length -gt 2 | Should -Be $true
 		}
 		It "Parameter Metadata" {
 			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
 			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FDESCRIPTION" -Level None -Value "Description of $userGroupName"
 			$ishObject = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName -Metadata $metadata
-			$ishObject.Count | Should Be 1
-			$ishObject.IshRef -Like "VUSER*" | Should Be $true
+			$ishObject.Count | Should -Be 1
+			$ishObject.IshRef -Like "VUSER*" | Should -Be $true
 		}
 		It "Parameter Metadata return descriptive metadata" {
 			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
 			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FDESCRIPTION" -Level None -Value "Description of $userGroupName"
 			$ishObject = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName -Metadata $metadata
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FDESCRIPTION -Level None).Length -gt 1 | Should Be $true
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERGROUPNAME -Level None).Length -gt 1 | Should Be $true
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.fishobjectactive.Length -ge 1 | Should Be $true 
-			$ishObject.fishusergroupname.Length -ge 1 | Should Be $true 
-			$ishObject.fishusergroupname_none_element.StartsWith('VUSERGROUP') | Should Be $true 
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FDESCRIPTION -Level None).Length -gt 1 | Should -Be $true
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERGROUPNAME -Level None).Length -gt 1 | Should -Be $true
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.fishobjectactive.Length -ge 1 | Should -Be $true 
+			$ishObject.fishusergroupname.Length -ge 1 | Should -Be $true 
+			$ishObject.fishusergroupname_none_element.StartsWith('VUSERGROUP') | Should -Be $true 
 		}
 		It "Parameter Metadata StrictMetadataPreference=Off" {
 			$strictMetadataPreference = $ishSession.StrictMetadataPreference
@@ -47,59 +47,60 @@ Describe “Add-IshUserGroup" -Tags "Create" {
 						Set-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -Level None -Value "SomethingReadAccess"  |
 						Set-IshMetadataField -IshSession $ishSession -Name "OWNER" -Level None -Value "SomethingOwner" |
 						Set-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level None -Value "SomethingInvalidFieldName"
-			{ Add-IshUserGroup -IshSession $ishSession -Name $userGroupName -Metadata $metadata } | Should Throw
+			{ Add-IshUserGroup -IshSession $ishSession -Name $userGroupName -Metadata $metadata } | Should -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 	}
-
-	Context “Add-IshUserGroup IshObjectsGroup" {
-		$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName
-		$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
-		              Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
-		$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
-		              Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
-		$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
-		              Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
-		$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
-		$ishObjectE = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName
-		$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
-		$ishObjectF = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
-		              Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
-		Remove-IshUserGroup -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
-		Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (...A12/10/2016 16:47:16)."
+	Context "Add-IshUserGroup IshObjectsGroup" {
+		BeforeAll {
+			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName
+			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
+						Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
+			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
+						Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
+			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
+						Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
+			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName
+			$userGroupName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshUserGroup -IshSession $ishSession -Name $userGroupName | 
+						Get-IshUserGroup -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERGROUPNAME")
+			Remove-IshUserGroup -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
+			Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (...A12/10/2016 16:47:16)."
+		}
 		It "Parameter IshObject invalid" {
-			{ Add-IshUserGroup -IShSession $ishSession -IshObject "INVALIDUSERGROUP" } | Should Throw
+			{ Add-IshUserGroup -IShSession $ishSession -IshObject "INVALIDUSERGROUP" } | Should -Throw
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			$ishObjects = Add-IshUserGroup -IshObject $ishObjectA
 			$ishObjects | Remove-IshUserGroup
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 			$ishObjects = Add-IshUserGroup -IshObject @($ishObjectB,$ishObjectC)
 			$ishObjects | Remove-IshUserGroup
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishObjects = $ishObjectD | Add-IshUserGroup -IshSession $ishSession
 			$ishObjects | Remove-IshUserGroup -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishObjects = @($ishObjectE,$ishObjectF) | Add-IshUserGroup -IshSession $ishSession
 			$ishObjects | Remove-IshUserGroup -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$userGroups = Find-IshUserGroup -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "FISHUSERGROUPNAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshUserGroup -IshSession $ishSession -IshObject $userGroups } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/UserRole/AddIshUserRole.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/UserRole/AddIshUserRole.Tests.ps1
@@ -1,42 +1,42 @@
-Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 for MyCommand[" + $MyInvocation.MyCommand + "]...")
-. (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\..\ISHRemote.PesterSetup.ps1")
-$cmdletName = "Add-IshUserRole"
-try {
+BeforeAll {
+	$cmdletName = "Add-IshUserRole"
+	Write-Host ("`r`nLoading ISHRemote.PesterSetup.ps1 over BeforeAll-block for MyCommand[" + $cmdletName + "]...")
+	. (Join-Path (Split-Path -Parent $PSCommandPath) "\..\..\ISHRemote.PesterSetup.ps1")
+
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables initialization")
+}
 
 Describe "Add-IshUserRole" -Tags "Create" {
-	Write-Host "Initializing Test Data and Variables"
-	
 	Context "Add-IshUserRole ParameterGroup" {
 		It "Parameter IshSession invalid" {
-			{ Add-IshUserRole -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERROLENAME" } | Should Throw
+			{ Add-IshUserRole -IShSession "INVALIDISHSESSION" -Name "INVALIDUSERROLENAME" } | Should -Throw
 		}
 	}
-
 	Context "Add-IshUserRole ParameterGroup" {
 		It "GetType().Name" {
 			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Name")
 			$ishObject = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
-			$ishObject.GetType().Name | Should BeExactly "IshUserRole"
-			$ishObject.Count | Should Be 1
-			(ConvertTo-Json $ishObject).Length -gt 2 | Should Be $true
+			$ishObject.GetType().Name | Should -BeExactly "IshUserRole"
+			$ishObject.Count | Should -Be 1
+			(ConvertTo-Json $ishObject).Length -gt 2 | Should -Be $true
 		}
 		It "Parameter Metadata" {
 			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
 			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FDESCRIPTION" -Level None -Value "Description of $userRoleName"
 			$ishObject = Add-IshUserRole -IshSession $ishSession -Name $userRoleName -Metadata $metadata
-			$ishObject.Count | Should Be 1
-			$ishObject.IshRef -Like "VUSER*" | Should Be $true
+			$ishObject.Count | Should -Be 1
+			$ishObject.IshRef -Like "VUSER*" | Should -Be $true
 		}
 		It "Parameter Metadata return descriptive metadata" {
 			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " Metadata")
 			$metadata = Set-IshMetadataField -IshSession $ishSession -Name "FDESCRIPTION" -Level None -Value "Description of $userRoleName"
 			$ishObject = Add-IshUserRole -IshSession $ishSession -Name $userRoleName -Metadata $metadata
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FDESCRIPTION -Level None).Length -gt 1 | Should Be $true
-			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERROLENAME -Level None).Length -gt 1 | Should Be $true
-			$ishSession.DefaultRequestedMetadata | Should Be "Basic"
-			$ishObject.fishobjectactive.Length -ge 1 | Should Be $true 
-			$ishObject.fishuserrolename.Length -ge 1 | Should Be $true 
-			$ishObject.fishuserrolename_none_element.StartsWith('VUSERROLE') | Should Be $true 
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FDESCRIPTION -Level None).Length -gt 1 | Should -Be $true
+			(Get-IshMetadataField -IshSession $ishSession -IshObject $ishObject -Name FISHUSERROLENAME -Level None).Length -gt 1 | Should -Be $true
+			$ishSession.DefaultRequestedMetadata | Should -Be "Basic"
+			$ishObject.fishobjectactive.Length -ge 1 | Should -Be $true 
+			$ishObject.fishuserrolename.Length -ge 1 | Should -Be $true 
+			$ishObject.fishuserrolename_none_element.StartsWith('VUSERROLE') | Should -Be $true 
 		}
 		It "Parameter Metadata StrictMetadataPreference=Off" {
 			$strictMetadataPreference = $ishSession.StrictMetadataPreference
@@ -47,58 +47,59 @@ Describe "Add-IshUserRole" -Tags "Create" {
 						Set-IshMetadataField -IshSession $ishSession -Name "READ-ACCESS" -Level None -Value "SomethingReadAccess"  |
 						Set-IshMetadataField -IshSession $ishSession -Name "OWNER" -Level None -Value "SomethingOwner" |
 						Set-IshMetadataField -IshSession $ishSession -Name "INVALIDFIELDNAME" -Level None -Value "SomethingInvalidFieldName"
-			{ Add-IshUserRole -IshSession $ishSession -Name $userRoleName -Metadata $metadata } | Should Throw
+			{ Add-IshUserRole -IshSession $ishSession -Name $userRoleName -Metadata $metadata } | Should -Throw
 			$ishSession.StrictMetadataPreference = $strictMetadataPreference
 		}
 	}
-
 	Context "Add-IshUserRole IshObjectsGroup" {
-		$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
-		$ishObjectA = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
-		$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
-		$ishObjectB = Add-IshUserRole -IshSession $ishSession -Name $userRoleName | 
-		              Get-IshUserRole -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERROLENAME")
-		$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
-		$ishObjectC = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
-		$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
-		$ishObjectD = Add-IshUserRole -IshSession $ishSession -Name $userRoleName | 
-		              Get-IshUserRole -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERROLENAME")
-		$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
-		$ishObjectE = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
-		$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
-		$ishObjectF = Add-IshUserRole -IshSession $ishSession -Name $userRoleName | 
-		              Get-IshUserRole -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERROLENAME")
-		Remove-IshUserRole -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
-		Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (VUSERROLEADD-ISHUSERROLE20161012164716068A12/10/2016 16:47:16)."
+		BeforeAll {
+			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " A")
+			$ishObjectA = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
+			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " B")
+			$ishObjectB = Add-IshUserRole -IshSession $ishSession -Name $userRoleName | 
+						Get-IshUserRole -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERROLENAME")
+			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " C")
+			$ishObjectC = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
+			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " D")
+			$ishObjectD = Add-IshUserRole -IshSession $ishSession -Name $userRoleName | 
+						Get-IshUserRole -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERROLENAME")
+			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " E")
+			$ishObjectE = Add-IshUserRole -IshSession $ishSession -Name $userRoleName
+			$userRoleName = ($cmdletName + " " + (Get-Date -Format "yyyyMMddHHmmssfff") + " F")
+			$ishObjectF = Add-IshUserRole -IshSession $ishSession -Name $userRoleName | 
+						Get-IshUserRole -IshSession $ishSession -RequestedMetadata (Set-IshRequestedMetadataField -IshSession $ishSession -Name "FISHUSERROLENAME")
+			Remove-IshUserRole -IshSession $ishSession -IshObject @($ishObjectA,$ishObjectB,$ishObjectC,$ishObjectD,$ishObjectE,$ishObjectF)
+			Start-Sleep -Milliseconds 1000  # Avoids uniquesness error which only up to the second " Cannot insert duplicate key row in object 'dbo.CARD' with unique index 'CARD_NAME_I1'. The duplicate key value is (VUSERROLEADD-ISHUSERROLE20161012164716068A12/10/2016 16:47:16)."
+		}
 		It "Parameter IshObject invalid" {
-			{ Add-IshUserRole -IShSession $ishSession -IshObject "INVALIDUSERROLE" } | Should Throw
+			{ Add-IshUserRole -IShSession $ishSession -IshObject "INVALIDUSERROLE" } | Should -Throw
 		}
 		It "Parameter IshObject Single with implicit IshSession" {
 			$ishObjects = Add-IshUserRole -IshObject $ishObjectA
 			$ishObjects | Remove-IshUserRole
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Parameter IshObject Multiple with implicit IshSession" {
 			$ishObjects = Add-IshUserRole -IshObject @($ishObjectB,$ishObjectC)
 			$ishObjects | Remove-IshUserRole
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 		It "Pipeline IshObject Single" {
 			$ishObjects = $ishObjectD | Add-IshUserRole -IshSession $ishSession
 			$ishObjects | Remove-IshUserRole -IshSession $ishSession
-			$ishObjects.Count | Should Be 1
+			$ishObjects.Count | Should -Be 1
 		}
 		It "Pipeline IshObject Multiple" {
 			$ishObjects = @($ishObjectE,$ishObjectF) | Add-IshUserRole -IshSession $ishSession
 			$ishObjects | Remove-IshUserRole -IshSession $ishSession
-			$ishObjects.Count | Should Be 2
+			$ishObjects.Count | Should -Be 2
 		}
 	}
 }
 
-
-} finally {
-	Write-Host "Cleaning Test Data and Variables"
+AfterAll {
+	Write-Host ("Running "+$cmdletName+" Test Data and Variables cleanup")
 	$userRoles = Find-IshUserRole -IshSession $ishSession -MetadataFilter (Set-IshMetadataFilterField -IshSession $ishSession -Name "FISHUSERROLENAME" -FilterOperator like -Value "$cmdletName%")
 	try { Remove-IshUserRole -IshSession $ishSession -IshObject $userRoles } catch { }
 }
+

--- a/Source/ISHRemote/Trisoft.ISHRemote/ISHRemote.PesterSetup.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/ISHRemote.PesterSetup.ps1
@@ -1,18 +1,27 @@
 ﻿#
 # Tests Header dot-sourced import PS1 file for *.Tests.ps1 files
 #
+
+# Quick check if you are using Pester 5, or default installed Pester 3.4.0 (#132)
+$pesterVersion = [version](Get-Command Invoke-Pester).Version
+if ($pesterVersion -lt [version]("5.3.0")) { Write-Warning ("ISHRemote.PesterSetup.ps1 Invoke-Pester version["+$pesterVersion+"] while 5.3+ is expected!") }
+
 $DebugPreference   = "SilentlyContinue"   # Continue or SilentlyContinue
 $VerbosePreference = "SilentlyContinue"   # Continue or SilentlyContinue
 $WarningPreference = "Continue"   # Continue or SilentlyContinue or Stop
 $ProgressPreference= "SilentlyContinue"   # Continue or SilentlyContinue
-Write-Host "Generating and Executing Import-Module Statement..."
+
+# Generating and Executing Import-Module Statement
 $project = (Split-Path -Parent $MyInvocation.MyCommand.Path).ToLower()
 $project = $project.Substring(0, $project.LastIndexOf("ishremote"))
 $project = ($project + "ishremote")
-Import-Module (Join-Path $project "\bin\debug\ISHRemote") -DisableNameChecking
-Write-Host    "Initializing Global Test Data and Variables"
+$moduleFolder = Join-Path $project "\bin\debug\ISHRemote"
+Write-Host ("Running ISHRemote.PesterSetup.ps1 Import Module folder["+$moduleFolder+"] ...")
+Import-Module ($moduleFolder) -DisableNameChecking
+
+Write-Host "Running ISHRemote.PesterSetup.ps1 Global Test Data and Variables initialization"
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
-Write-Verbose "Initializing OASIS DITA File Contents"
+Write-Verbose "Running ISHRemote.PesterSetup.ps1 OASIS DITA File Contents initialization"
 $ditaTopicFileContent = @"
 <?xml version="1.0" ?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
@@ -31,14 +40,14 @@ $ditaMapWithTopicrefFileContent = @"
 </map>
 "@
 
-Write-Verbose "Initializing variables for UserName/Password based tests, so ISHSTS-like..."
+Write-Verbose "Running ISHRemote.PesterSetup.ps1 variables for UserName/Password based tests, so ISHSTS-like...initialization"
 $baseUrl = 'https://ish.example.com'
 $webServicesBaseUrl = "$baseUrl/ISHWS/"  # must have trailing slash for tests to succeed
 $wsTrustIssuerUrl = "$baseUrl/ISHSTS/issue/wstrust/mixed/username"
 $wsTrustIssuerMexUrl = "$baseUrl/ISHSTS/issue/wstrust/mex"
 $ishUserName = 'admin'
 $ishPassword = 'admin'
-Write-Verbose "Initializing variables for System Setup"
+Write-Verbose "Running ISHRemote.PesterSetup.ps1 variables for System Setup initialization"
 $folderTestRootPath = "\General\__ISHRemote"  # requires leading FolderPathSeparator for tests to succeed
 $ishLng = 'VLANGUAGEEN'
 $ishLngLabel = 'en'
@@ -57,7 +66,7 @@ $ishLovId2 = "DRESOLUTION"  # ListOfValues where the Lov tests will work on
 $ishEventTypeToPurge = "PUSHTRANSLATIONS"
 
 #region Placeholder to inject your variable overrides. 
-Write-Host    "Initializing Global Test Data and Variables for debug"
+Write-Host "Running ISHRemote.PesterSetup.ps1 Global Test Data and Variables for debug initialization"
 $debugPesterSetupFilePath = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "ISHRemote.PesterSetup.Debug.ps1"
 if (Test-Path -Path $debugPesterSetupFilePath -PathType Leaf)
 {

--- a/Source/ISHRemote/Trisoft.ISHRemote/Objects/Public/IshSession.cs
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Objects/Public/IshSession.cs
@@ -390,7 +390,7 @@ namespace Trisoft.ISHRemote.Objects.Public
         public int MetadataBatchSize
         {
             get { return _metadataBatchSize; }
-            set { _metadataBatchSize = value; }
+            set { _metadataBatchSize = (value > 0) ? value : 999; }
         }
 
         /// <summary>


### PR DESCRIPTION
All `*.Tests.p1` have been transformed in Pester v5.3.0 which also runs about twice as fast. And is ready for @ivandelagemaat PowerShell 7+ efforts :-) 
* As you can read in #132, most of the effort was done by a script. The occasional manual adjustment regarding exception-checking, array-comparison, etc
* Remember, requires `Install-Module -Name Pester -Force -SkipPublisherCheck` which will overwrite your existing Pester 3.4.0. Side by side is also possible, if you still need older Pester for other projects.

PS: the branch technically was called 115, it was indeed about #132